### PR TITLE
Fix Docker implementation for MCP protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ To use the containerized server with Claude Desktop, update the configuration to
 
 This configuration passes the environment variables from Claude Desktop to the Docker container by using the `-e` flag with just the variable name, and providing the actual values in the `env` object.
 
+> **Note about Docker implementation**: The Docker setup has been updated to match the structure of the chess-mcp project, which has been proven to work correctly with Claude. The new implementation uses a multi-stage build process and runs the entry point script directly without an intermediary shell script. This approach ensures proper handling of stdin/stdout for MCP communication.
+
 ## Development
 
 Contributions are welcome! Please open an issue or submit a pull request if you have any suggestions or improvements.


### PR DESCRIPTION
## Purpose

This PR fixes the issue reported in #2 where the Prometheus MCP server fails to work with Claude correctly. The root cause is related to how the server is being executed in Docker and how the stdin/stdout handling is managed for the MCP protocol.

## Changes Made

The following changes have been implemented:

1. **Completely Rewrote the Dockerfile**:
   - Changed to a multi-stage build pattern similar to chess-mcp
   - Removed the docker-entrypoint.sh script in favor of direct command execution
   - Added proper user permissions with non-root user
   - Set environment variables to ensure proper stdout handling (`PYTHONUNBUFFERED=1`)
   - Added healthcheck for better container monitoring

2. **Added Documentation**:
   - Updated README.md with information about the Docker implementation changes

## Testing

The implementation is based on the chess-mcp project, which is confirmed to work correctly with Claude. The changes focus specifically on how the Docker container executes the MCP server, ensuring clean stdin/stdout channels for the JSON communication protocol.

## Related Issues

This PR addresses the issue reported in #2 where users experience errors when using the MCP server with Claude.

## Notes

The key insight is that the Model Context Protocol (MCP) uses stdin/stdout for communication with JSON messages. The previous implementation may have caused issues by:
1. Using a shell script intermediate (docker-entrypoint.sh)
2. Not setting proper Python output buffering
3. Not having a clean execution path for stdin/stdout handling

These changes ensure that the Prometheus MCP server behaves consistently with the chess-mcp server, which works correctly with Claude.