### PR TITLE
Add MCP badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Prometheus MCP Server
 
+![](https://badge.mcpx.dev 'MCP')
+
 A [Model Context Protocol][mcp] (MCP) server for Prometheus.
 
 This provides access to your Prometheus metrics and queries through standardized MCP interfaces, allowing AI assistants to execute PromQL queries and analyze your metrics data.


### PR DESCRIPTION
This PR adds the standard MCP badge to the README file for better visibility and consistency across MCP servers.