### PR TITLE
Add X-Scope-OrgId header support for multi-tenancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ PROMETHEUS_PASSWORD=your_password
 
 # For bearer token auth
 PROMETHEUS_TOKEN=your_token
+
+# Optional: For multi-tenant setups like Cortex, Mimir or Thanos
+ORG_ID=your_organization_id
 ```
 
 3. Add the server configuration to your client configuration file. For example, for Claude Desktop:


### PR DESCRIPTION
To be able to use this MCP server with a multi-tenant setup of Cortex, Mimir or Thanos:

https://grafana.com/docs/mimir/latest/manage/secure/authentication-and-authorization/#grafana-mimir-authentication-and-authorization