### PR TITLE
Add Docker build and push workflow

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,0 +1,58 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [ "main" ]
+    tags: [ "v*" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,format=long
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -81,9 +81,23 @@ ORG_ID=your_organization_id
 
 This project includes Docker support for easy deployment and isolation.
 
-### Building the Docker Image
+### Pre-built Docker Image
 
-Build the Docker image using:
+The easiest way to use this project is with the pre-built image from GitHub Container Registry:
+
+```bash
+docker pull ghcr.io/pab1it0/prometheus-mcp-server:latest
+```
+
+You can also use specific versions with tags:
+
+```bash
+docker pull ghcr.io/pab1it0/prometheus-mcp-server:1.0.0
+```
+
+### Building the Docker Image Locally
+
+If you prefer to build the image yourself:
 
 ```bash
 docker build -t prometheus-mcp-server .
@@ -93,7 +107,17 @@ docker build -t prometheus-mcp-server .
 
 You can run the server using Docker in several ways:
 
-#### Using docker run directly:
+#### Using docker run with the pre-built image:
+
+```bash
+docker run -it --rm \
+  -e PROMETHEUS_URL=http://your-prometheus-server:9090 \
+  -e PROMETHEUS_USERNAME=your_username \
+  -e PROMETHEUS_PASSWORD=your_password \
+  ghcr.io/pab1it0/prometheus-mcp-server:latest
+```
+
+#### Using docker run with a locally built image:
 
 ```bash
 docker run -it --rm \
@@ -127,7 +151,7 @@ To use the containerized server with Claude Desktop, update the configuration to
         "-e", "PROMETHEUS_URL",
         "-e", "PROMETHEUS_USERNAME",
         "-e", "PROMETHEUS_PASSWORD",
-        "prometheus-mcp-server"
+        "ghcr.io/pab1it0/prometheus-mcp-server:latest"
       ],
       "env": {
         "PROMETHEUS_URL": "http://your-prometheus-server:9090",


### PR DESCRIPTION
## Description

This PR adds a GitHub Action workflow to automatically build and push Docker images to GitHub Container Registry (GHCR).

### Features

- Automatic builds on pushes to main branch and tags
- Validation builds on pull requests
- Intelligent tagging for Docker images based on:
  - Branch names
  - Semantic versions from tags (v1.0.0 → 1.0.0, 1.0, 1)
  - Git SHA

### How to Use

Once merged, the workflow will automatically:
1. Build Docker images for every push and PR
2. Push images to GHCR when:
   - Pushing to main branch (tagged with 'main')
   - Pushing a version tag (e.g., v1.0.0)

The Docker images will be available at:
```
ghcr.io/pab1it0/prometheus-mcp-server:tag
```

### Notes

- Uses GitHub's built-in GITHUB_TOKEN for authentication
- Configures caching to speed up subsequent builds
- Respects existing Docker build configuration