### PR TITLE
feat: Add arm64 support for Docker builds

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -54,5 +57,6 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ CMD ["/app/.venv/bin/prometheus-mcp-server"]
 # GitHub Container Registry Metadata
 LABEL org.opencontainers.image.title="Prometheus MCP Server" \
   org.opencontainers.image.description="Model Context Protocol server for Prometheus integration" \
-  org.opencontainers.image.version="1.0.1" \
+  org.opencontainers.image.version="1.0.4" \
   org.opencontainers.image.authors="Pavel Shklovsky" \
   org.opencontainers.image.source="https://github.com/pab1it0/prometheus-mcp-server" \
   org.opencontainers.image.licenses="MIT" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ CMD ["/app/.venv/bin/prometheus-mcp-server"]
 # GitHub Container Registry Metadata
 LABEL org.opencontainers.image.title="Prometheus MCP Server" \
   org.opencontainers.image.description="Model Context Protocol server for Prometheus integration" \
-  org.opencontainers.image.version="1.0.3" \
+  org.opencontainers.image.version="1.0.1" \
   org.opencontainers.image.authors="Pavel Shklovsky" \
   org.opencontainers.image.source="https://github.com/pab1it0/prometheus-mcp-server" \
   org.opencontainers.image.licenses="MIT" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prometheus_mcp_server"
-version = "1.0.0"
+version = "1.0.1"
 description = "MCP server for Prometheus integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prometheus_mcp_server"
-version = "1.0.1"
+version = "1.0.4"
 description = "MCP server for Prometheus integration"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Description
Adds multi-platform Docker build support including arm64 architecture for Apple Silicon Macs.

## Changes
- Added QEMU setup in GitHub Actions workflow for cross-platform builds
- Configured Docker buildx to build for both `linux/amd64` and `linux/arm64`
- Bumped version from 1.0.0 to 1.0.1

## Testing
The Docker image will now be built for both architectures when pushed to the registry.

Fixes #20