### PR TITLE
Fix list_metrics error with list response handling

### DIFF
--- a/src/prometheus_mcp_server/server.py
+++ b/src/prometheus_mcp_server/server.py
@@ -76,7 +76,12 @@ def make_prometheus_request(endpoint, params=None):
             logger.error("Prometheus API returned error", endpoint=endpoint, error=error_msg, status=result["status"])
             raise ValueError(f"Prometheus API error: {error_msg}")
         
-        logger.debug("Prometheus API request successful", endpoint=endpoint, result_type=result.get("data", {}).get("resultType"))
+        data_field = result.get("data", {})
+        if isinstance(data_field, dict):
+            result_type = data_field.get("resultType")
+        else:
+            result_type = "list"
+        logger.debug("Prometheus API request successful", endpoint=endpoint, result_type=result_type)
         return result["data"]
     
     except requests.exceptions.RequestException as e:


### PR DESCRIPTION
The list_metrics function was failing with AttributeError: 'list' object has no attribute 'get' on line 79. This occurred because the /api/v1/label/__name__/values endpoint returns a list directly in the data field, not a dictionary with resultType.

Added proper handling for both list and dictionary responses in the debug logging to prevent the error while maintaining compatibility with other endpoints that return dictionary responses.