### PR TITLE
Remove non-functional health check from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,15 +31,11 @@ ENV PATH="/app/.venv/bin:$PATH" \
   PYTHONPATH="/app" \
   PYTHONFAULTHANDLER=1
 
-# Curl for HEALTHCHECK
-RUN apt-get update && apt-get install -y curl
 
 USER app
 
 EXPOSE 8000
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-  CMD curl -f http://localhost:8000/health || exit 1
 
 CMD ["/app/.venv/bin/prometheus-mcp-server"]
 


### PR DESCRIPTION
The health check was trying to access http://localhost:8000/health but the server only runs in stdio mode and doesn't expose any HTTP endpoints. This resulted in containers always being marked as unhealthy.

Also removed curl installation as it was only used for the health check.