### PR TITLE
Fix GitHub Action to support fork PRs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,67 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@beta
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+          
+          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
+          # model: "claude-opus-4-1-20250805"
+          
+          # Optional: Customize the trigger phrase (default: @claude)
+          # trigger_phrase: "/claude"
+          
+          # Optional: Trigger when specific user is assigned to an issue
+          # assignee_trigger: "claude-bot"
+          
+          # Optional: Allow Claude to run specific commands
+          # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
+          
+          # Optional: Add custom instructions for Claude to customize its behavior for your project
+          # custom_instructions: |
+          #   Follow our coding standards
+          #   Ensure all new code has tests
+          #   Use TypeScript for new files
+          
+          # Optional: Custom environment variables for Claude
+          # claude_env: |
+          #   NODE_ENV: test
+


### PR DESCRIPTION
## Problem

The Claude Code GitHub Action was failing when processing PRs from forked repositories with the error:
```
fatal: couldn't find remote ref feat/add-pagination-and-limits
```

This occurred because the `actions/checkout@v4` step was configured with `fetch-depth: 1` and only checked out the base repository, not the fork where the PR branch actually exists.

## Solution

Updated the checkout configuration in `.github/workflows/claude.yml`:

- **Changed `fetch-depth`**: From `1` to `0` to fetch full git history
- **Added `ref`**: `${{ github.event.pull_request.head.ref }}` to checkout the specific PR branch
- **Added `repository`**: `${{ github.event.pull_request.head.repo.full_name }}` to access fork repositories  
- **Added `token`**: `${{ secrets.GITHUB_TOKEN }}` for proper authentication

## Impact

- ✅ Fixes processing of fork PRs like #39 from `temujin9/prometheus-mcp-server`
- ✅ Maintains compatibility with same-repository PRs
- ✅ Enables Claude to access files that exist only in fork branches
- ✅ Resolves the checkout failure that prevented the action from running

## Testing

This fix will be validated when:
- Fork PR contributors mention `@claude` in their PRs
- The action successfully checks out the fork branch
- Claude can process files like `tests/test_pagination.py` from the fork

Related to issue with PR #39 where the action couldn't access the `feat/add-pagination-and-limits` branch.