### PR TITLE
Revert GitHub Action fork PR support

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -28,10 +28,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 1
 
       - name: Run Claude Code
         id: claude


### PR DESCRIPTION
## Purpose

This PR reverts the fork PR support changes that were added to the Claude Code GitHub Action workflow.

## Changes Reverted

Reverts the following changes from `.github/workflows/claude.yml`:

- **Restored `fetch-depth`**: Changed back from `0` to `1` 
- **Removed `ref`**: Removed `${{ github.event.pull_request.head.ref }}`
- **Removed `repository`**: Removed `${{ github.event.pull_request.head.repo.full_name }}`
- **Removed `token`**: Removed `${{ secrets.GITHUB_TOKEN }}`

## Back to Original Configuration

The checkout step now uses the simple original configuration:

```yaml
- name: Checkout repository
  uses: actions/checkout@v4
  with:
    fetch-depth: 1
```

## Reason for Revert

Reverting to the simpler configuration for workflow stability and to remove the fork-specific handling that was previously added.

## Impact

- ✅ Restores original workflow behavior
- ✅ Simplifies the checkout configuration  
- ❌ Fork PRs will not be processed by the Claude action (returns to previous behavior)

This reverts the workflow to its state before the fork PR support was added.