### PR TITLE
Missing docs on mcp server configuration

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -12,8 +12,8 @@ PROMETHEUS_PASSWORD=your_password
 PROMETHEUS_TOKEN=your_token
 
 # Optional: Custom MCP configuration
-# PROMETHEUS_MCP_SERVER_TRANSPORT=stdio # Choose between http/stdio/sse, if undefined, stdio is used
+# PROMETHEUS_MCP_SERVER_TRANSPORT=stdio # Choose between http, stdio, sse. If undefined, stdio is set as the default transport.
 
 # Optional: Only relevant for non-stdio transports
-# PROMETHEUS_MCP_BIND_HOST=localhost # if undefined, 127.0.0.1 is used
-# PROMETHEUS_MCP_BIND_PORT=8080 # if undefined, 8080 is used
+# PROMETHEUS_MCP_BIND_HOST=localhost # if undefined, 127.0.0.1 is set by default.
+# PROMETHEUS_MCP_BIND_PORT=8080 # if undefined, 8080 is set by default.

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ PROMETHEUS_PASSWORD=your_password
 PROMETHEUS_TOKEN=your_token
 
 # Optional: Custom MCP configuration
-PROMETHEUS_MCP_SERVER_TRANSPORT=stdio # Choose between http/stdio/sse, if undefined, stdio is used
+PROMETHEUS_MCP_SERVER_TRANSPORT=stdio # Choose between http, stdio, sse. If undefined, stdio is set as the default transport.
 
 # Optional: Only relevant for non-stdio transports
-PROMETHEUS_MCP_BIND_HOST=localhost # if undefined, 127.0.0.1 is used
-PROMETHEUS_MCP_BIND_PORT=8080 # if undefined, 8080 is used
+PROMETHEUS_MCP_BIND_HOST=localhost # if undefined, 127.0.0.1 is set by default.
+PROMETHEUS_MCP_BIND_PORT=8080 # if undefined, 8080 is set by default.
 
 # Optional: For multi-tenant setups like Cortex, Mimir or Thanos
 ORG_ID=your_organization_id

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,6 +37,14 @@ If multiple authentication methods are configured, the server will prioritize th
 2. Basic authentication (if both `PROMETHEUS_USERNAME` and `PROMETHEUS_PASSWORD` are set)
 3. No authentication (if no credentials are provided)
 
+#### MCP Server Configuration
+
+| Variable | Description | Example |
+|----------|-------------|--------|
+| `PROMETHEUS_MCP_SERVER_TRANSPORT` | Choose between these transports: `http`, `stdio`, `sse`. If undefined,  `stdio` is set as the default transport. | `http` |
+| `PROMETHEUS_MCP_BIND_HOST` | Define the host for your MCP server, if undefined, `127.0.0.1` is set by default. | `localhost` |
+| `PROMETHEUS_MCP_BIND_PORT` | Define the port where your MCP server is exposed, if undefined, `8080` is set by default. | `8080` |
+
 ## MCP Client Configuration
 
 ### Claude Desktop Configuration

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -83,10 +83,10 @@ PROMETHEUS_PASSWORD=your_password
 PROMETHEUS_TOKEN=your_token
 
 # Optional: Custom MCP configuration
-PROMETHEUS_MCP_SERVER_TRANSPORT=http # Choose between http/stdio/sse, if undefined, stdio is used
+# PROMETHEUS_MCP_SERVER_TRANSPORT=stdio # Choose between http, stdio, sse. If undefined, stdio is set as the default transport.
 # Optional: Only relevant for non-stdio transports
-# PROMETHEUS_MCP_BIND_HOST=localhost # if undefined, 127.0.0.1 is used
-# PROMETHEUS_MCP_BIND_PORT=8080 # if undefined, 8080 is used
+# PROMETHEUS_MCP_BIND_HOST=localhost # if undefined, 127.0.0.1 is set by default.
+# PROMETHEUS_MCP_BIND_PORT=8080 # if undefined, 8080 is set by default.
 ```
 
 ## Running the Server


### PR DESCRIPTION
Hi @pab1it0 

Thank you for the speedy review on the recent PR, greatly appreciate it!

Please help to review this small PR that addresses the missing docs on the custom MCP Server Configuration in `docs/configuration.md`.