### PR TITLE
Fix claude-review workflow OIDC token permissions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,6 +24,7 @@ jobs:
       pull-requests: read
       issues: read
       id-token: write
+      actions: read # Required for Claude to read CI results on PRs
     
     steps:
       - name: Checkout repository
@@ -36,6 +37,10 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
           # model: "claude-opus-4-1-20250805"


### PR DESCRIPTION
## Summary

Fixes the failing claude-review GitHub Actions workflow that was encountering OIDC token setup errors.

## Changes Made

- **Added missing `actions: read` permission** to the workflow permissions section
- **Added `additional_permissions` configuration** to the claude-code-action step
- **Aligned configuration with working claude.yml workflow**

## Problem Solved

The claude-review workflow was failing with:
> Failed to setup GitHub token: Error: Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?

While the `id-token: write` permission was already present, the action also needed the `actions: read` permission to properly handle CI results and token setup.

## Test Plan

- [x] Workflow configuration updated and committed
- [x] Changes align with working claude.yml workflow
- [ ] Verify the workflow runs successfully on this PR

Resolves the failing check on PR #48.