### PR TITLE
chore: Bump version to 1.2.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ CMD ["/app/.venv/bin/prometheus-mcp-server"]
 # GitHub Container Registry Metadata
 LABEL org.opencontainers.image.title="Prometheus MCP Server" \
   org.opencontainers.image.description="Model Context Protocol server for Prometheus integration" \
-  org.opencontainers.image.version="1.2.2" \
+  org.opencontainers.image.version="1.2.3" \
   org.opencontainers.image.authors="Pavel Shklovsky" \
   org.opencontainers.image.source="https://github.com/pab1it0/prometheus-mcp-server" \
   org.opencontainers.image.licenses="MIT" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prometheus_mcp_server"
-version = "1.2.2"
+version = "1.2.3"
 description = "MCP server for Prometheus integration"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Bump version from 1.2.2 to 1.2.3 in both pyproject.toml and Dockerfile
- Prepares for new release with pagination revert changes

## Changes
- Updated version in `pyproject.toml` to 1.2.3
- Updated Docker image version label in `Dockerfile` to 1.2.3

## Test plan
- [x] Version updated in both files
- [x] Clean build and push ready for release