### PR TITLE
Fix Claude Code installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,23 +67,12 @@ Add to your Claude Desktop configuration:
 </details>
 
 <details>
-<summary><b>Claude Code (CLI)</b></summary>
+<summary><b>Claude Code</b></summary>
 
 Install via the Claude Code CLI:
 
 ```bash
-claude code add prometheus-mcp-server
-```
-
-Then configure your Prometheus connection:
-
-```bash
-# Set your Prometheus URL
-claude code config set prometheus-mcp-server PROMETHEUS_URL "http://your-prometheus:9090"
-
-# Optional: Set authentication
-claude code config set prometheus-mcp-server PROMETHEUS_USERNAME "admin"
-claude code config set prometheus-mcp-server PROMETHEUS_PASSWORD "password"
+claude mcp add prometheus --env PROMETHEUS_URL=http://your-prometheus:9090 -- docker run -i --rm -e PROMETHEUS_URL ghcr.io/pab1it0/prometheus-mcp-server:latest
 ```
 </details>
 


### PR DESCRIPTION
## Summary

Corrects the Claude Code installation instructions in the README which contained incorrect CLI commands that don't exist.

## Changes Made

- **Fixed CLI command**: Changed `claude code add` to the correct `claude mcp add`
- **Removed invalid config commands**: Replaced non-existent `claude code config set` commands with proper `--env` flag usage
- **Simplified section title**: Removed "(CLI)" from "Claude Code (CLI)" 
- **Streamlined instructions**: Kept only the basic case with `PROMETHEUS_URL` for simplicity

## Before
```bash
claude code add prometheus-mcp-server
claude code config set prometheus-mcp-server PROMETHEUS_URL "http://your-prometheus:9090"
```

## After  
```bash
claude mcp add prometheus --env PROMETHEUS_URL=http://your-prometheus:9090 -- docker run -i --rm -e PROMETHEUS_URL ghcr.io/pab1it0/prometheus-mcp-server:latest
```

## Impact

Users can now actually follow the installation instructions to successfully add the Prometheus MCP server to Claude Code.