### PR TITLE
Optimize test workflow: Python 3.12 only + test results upload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,21 +8,17 @@ on:
 
 jobs:
   test:
-    name: Test Python ${{ matrix.python-version }}
+    name: Test Python 3.12
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10", "3.11", "3.12"]
-      fail-fast: false
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.12"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -43,8 +39,13 @@ jobs:
           pytest --cov-report=xml --cov-fail-under=89
 
       - name: Upload coverage to Codecov
-        if: matrix.python-version == '3.12'
         uses: codecov/codecov-action@v4
         with:
           file: ./coverage.xml
           fail_ci_if_error: false
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run tests with coverage
         run: |
           source .venv/bin/activate
-          pytest --cov-report=xml --cov-fail-under=89
+          pytest --cov --junitxml=junit.xml -o junit_family=legacy --cov-report=xml --cov-fail-under=89
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
@@ -48,4 +48,5 @@ jobs:
         if: ${{ !cancelled() }}
         uses: codecov/test-results-action@v1
         with:
+          file: ./junit.xml
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

Simplifies the test workflow to run only on Python 3.12 and adds test results upload to Codecov for better visibility.

## Changes Made

- **Simplified Python versions**: Removed matrix strategy, test only Python 3.12 for faster CI
- **Added test results upload**: New step uploads test results to Codecov after coverage
- **Removed matrix complexity**: Updated job name and step references to remove matrix variables
- **Cleaner workflow**: No conditional logic needed since single Python version

## Before
- Matrix testing: Python 3.10, 3.11, 3.12 (3 parallel jobs)
- Only coverage upload to Codecov
- Conditional coverage upload based on matrix version

## After  
- Single job: Python 3.12 only
- Both coverage and test results uploaded to Codecov
- Test results upload with `!cancelled()` condition for reliability

## Benefits

- **Faster CI**: Single job instead of 3 parallel jobs
- **Better visibility**: Test results visible in Codecov dashboard
- **Simplified maintenance**: No matrix complexity to manage
- **Reliable uploads**: Test results upload even if previous steps fail