### PR TITLE
feat: configure MCP registry with GitHub authentication and Docker validation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ CMD ["/app/.venv/bin/prometheus-mcp-server"]
 
 LABEL org.opencontainers.image.title="Prometheus MCP Server" \
       org.opencontainers.image.description="Model Context Protocol server for Prometheus integration, enabling AI assistants to query metrics and monitor system health" \
-      org.opencontainers.image.version="1.2.5" \
+      org.opencontainers.image.version="1.2.6" \
       org.opencontainers.image.authors="Pavel Shklovsky <pavel@cloudefined.com>" \
       org.opencontainers.image.source="https://github.com/pab1it0/prometheus-mcp-server" \
       org.opencontainers.image.licenses="MIT" \
@@ -74,6 +74,7 @@ LABEL org.opencontainers.image.title="Prometheus MCP Server" \
       org.opencontainers.image.base.name="python:3.12-slim-bookworm" \
       org.opencontainers.image.created="" \
       org.opencontainers.image.revision="" \
+      io.modelcontextprotocol.server.name="io.github.pab1it0/prometheus-mcp-server" \
       mcp.server.name="prometheus-mcp-server" \
       mcp.server.category="monitoring" \
       mcp.server.tags="prometheus,monitoring,metrics,observability" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prometheus_mcp_server"
-version = "1.2.5"
+version = "1.2.6"
 description = "MCP server for Prometheus integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "name": "io.github.pab1it0/prometheus-mcp-server",
+  "description": "MCP server for Prometheus integration, enabling AI assistants to query metrics and monitor system health",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/pab1it0/prometheus-mcp-server",
+    "source": "github"
+  },
+  "version": "1.2.6",
+  "packages": [
+    {
+      "registry_type": "oci",
+      "registry_base_url": "https://ghcr.io",
+      "identifier": "pab1it0/prometheus-mcp-server",
+      "version": "1.2.6",
+      "transport": {
+        "type": "stdio"
+      },
+      "environment_variables": [
+        {
+          "description": "Prometheus server URL (e.g., http://localhost:9090)",
+          "is_required": true,
+          "format": "string",
+          "is_secret": false,
+          "name": "PROMETHEUS_URL"
+        },
+        {
+          "description": "Username for Prometheus basic authentication",
+          "is_required": false,
+          "format": "string",
+          "is_secret": false,
+          "name": "PROMETHEUS_USERNAME"
+        },
+        {
+          "description": "Password for Prometheus basic authentication",
+          "is_required": false,
+          "format": "string",
+          "is_secret": true,
+          "name": "PROMETHEUS_PASSWORD"
+        },
+        {
+          "description": "Bearer token for Prometheus authentication",
+          "is_required": false,
+          "format": "string",
+          "is_secret": true,
+          "name": "PROMETHEUS_TOKEN"
+        },
+        {
+          "description": "Organization ID for multi-tenant Prometheus setups",
+          "is_required": false,
+          "format": "string",
+          "is_secret": false,
+          "name": "ORG_ID"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add server.json configuration for MCP registry publication
- Configure GitHub namespace io.github.pab1it0/prometheus-mcp-server  
- Switch from PyPI to OCI registry type for Docker images
- Add proper Prometheus environment variables configuration
- Add required MCP server name label to Dockerfile for package validation
- Bump version to 1.2.6

## Changes Made
### server.json
- Created new MCP registry configuration file
- Set GitHub namespace: `io.github.pab1it0/prometheus-mcp-server`
- Changed from PyPI to OCI registry type pointing to ghcr.io
- Added all Prometheus-specific environment variables (PROMETHEUS_URL, PROMETHEUS_USERNAME, PROMETHEUS_PASSWORD, PROMETHEUS_TOKEN, ORG_ID)
- Updated to version 1.2.6

### Dockerfile  
- Added required MCP server name label: `io.modelcontextprotocol.server.name="io.github.pab1it0/prometheus-mcp-server"`
- This label is required for Docker/OCI package validation in the MCP registry
- Updated version to 1.2.6

### pyproject.toml
- Bumped version from 1.2.5 to 1.2.6

## Validation
This configuration enables:
- ✅ GitHub authentication via proper namespace format
- ✅ Docker/OCI Images package validation with required labels
- ✅ Proper environment variable configuration for Prometheus
- ✅ Publication to the Model Context Protocol registry

Resolves the requirements for MCP registry publication with GitHub authentication and Docker validation.