### PR TITLE
fix: add GH_TOKEN for MCP Publisher and bump to v1.2.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,8 @@ jobs:
           --repo "$GITHUB_REPOSITORY"
 
       - name: Install MCP Publisher
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           gh extension install modelcontextprotocol/gh-mcp-publish
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ CMD ["/app/.venv/bin/prometheus-mcp-server"]
 
 LABEL org.opencontainers.image.title="Prometheus MCP Server" \
       org.opencontainers.image.description="Model Context Protocol server for Prometheus integration, enabling AI assistants to query metrics and monitor system health" \
-      org.opencontainers.image.version="1.2.8" \
+      org.opencontainers.image.version="1.2.9" \
       org.opencontainers.image.authors="Pavel Shklovsky <pavel@cloudefined.com>" \
       org.opencontainers.image.source="https://github.com/pab1it0/prometheus-mcp-server" \
       org.opencontainers.image.licenses="MIT" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prometheus_mcp_server"
-version = "1.2.8"
+version = "1.2.9"
 description = "MCP server for Prometheus integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/pab1it0/prometheus-mcp-server",
     "source": "github"
   },
-  "version": "1.2.8",
+  "version": "1.2.9",
   "packages": [
     {
       "registry_type": "oci",
       "registry_base_url": "https://ghcr.io",
       "identifier": "pab1it0/prometheus-mcp-server",
-      "version": "1.2.8",
+      "version": "1.2.9",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
- Fix missing GH_TOKEN environment variable in MCP Publisher installation step
- Bump version to 1.2.9 across all relevant files

## Changes
- Added `GH_TOKEN: ${{ github.token }}` to Install MCP Publisher step in CI workflow
- Updated version to 1.2.9 in:
  - pyproject.toml
  - server.json (both version fields)
  - Dockerfile (image label)

## Test plan
- [x] Verify CI workflow syntax is valid
- [ ] Test deployment workflow after merge

Fixes deployment failure from https://github.com/pab1it0/prometheus-mcp-server/actions/runs/17883715762/job/50854729518