### PR TITLE
chore: bump version to 1.2.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ CMD ["/app/.venv/bin/prometheus-mcp-server"]
 
 LABEL org.opencontainers.image.title="Prometheus MCP Server" \
       org.opencontainers.image.description="Model Context Protocol server for Prometheus integration, enabling AI assistants to query metrics and monitor system health" \
-      org.opencontainers.image.version="1.2.9" \
+      org.opencontainers.image.version="1.2.10" \
       org.opencontainers.image.authors="Pavel Shklovsky <pavel@cloudefined.com>" \
       org.opencontainers.image.source="https://github.com/pab1it0/prometheus-mcp-server" \
       org.opencontainers.image.licenses="MIT" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prometheus_mcp_server"
-version = "1.2.9"
+version = "1.2.10"
 description = "MCP server for Prometheus integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/pab1it0/prometheus-mcp-server",
     "source": "github"
   },
-  "version": "1.2.9",
+  "version": "1.2.10",
   "packages": [
     {
       "registry_type": "oci",
       "registry_base_url": "https://ghcr.io",
       "identifier": "pab1it0/prometheus-mcp-server",
-      "version": "1.2.9",
+      "version": "1.2.10",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
- Bump patch version to 1.2.10 across all relevant files
- Prepare for next release

## Changes
- Updated version to 1.2.10 in:
  - pyproject.toml
  - server.json (both version fields)
  - Dockerfile (image label)

## Test plan
- [x] Verify CI workflow passes
- [ ] Test deployment workflow after merge and tag

Ready for merge and tagging with v1.2.10