### PR TITLE
fix: update MCP Publisher workflow to use official CLI tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,13 +161,11 @@ jobs:
           --repo "$GITHUB_REPOSITORY"
 
       - name: Install MCP Publisher
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
-          gh extension install modelcontextprotocol/gh-mcp-publish
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.0.0/mcp-publisher_1.0.0_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Login to MCP Registry
+        run: ./mcp-publisher login github-oidc
 
       - name: Publish to MCP Registry
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          gh mcp-publish --schema-path server.json
+        run: ./mcp-publisher publish


### PR DESCRIPTION
## Summary
Fix the deployment workflow by replacing the non-existent GitHub CLI extension with the official MCP publisher CLI tool.

## Problem
The current workflow tries to install `modelcontextprotocol/gh-mcp-publish` which doesn't exist, causing deployment failures.

## Solution
Updated the workflow based on the official MCP registry documentation:
- Replace `gh extension install` with direct CLI download
- Use proper `mcp-publisher login github-oidc` command
- Use `mcp-publisher publish` command

## Changes
- **Install MCP Publisher**: Downloads official CLI tool from GitHub releases
- **Login to MCP Registry**: Uses GitHub OIDC authentication
- **Publish to MCP Registry**: Uses official publish command
- **Removed**: Non-existent GitHub CLI extension and manual token handling

## References
- [Official MCP Registry GitHub Actions Guide](https://github.com/modelcontextprotocol/registry/blob/main/docs/guides/publishing/github-actions.md)

## Test plan
- [x] Verify CI workflow syntax is valid
- [ ] Test deployment workflow after merge and tag

This fix ensures the MCP registry publishing step will work correctly in deployments.