### PR TITLE
feat: bump to v1.3.0 - adding MCP registry deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ CMD ["/app/.venv/bin/prometheus-mcp-server"]
 
 LABEL org.opencontainers.image.title="Prometheus MCP Server" \
       org.opencontainers.image.description="Model Context Protocol server for Prometheus integration, enabling AI assistants to query metrics and monitor system health" \
-      org.opencontainers.image.version="1.2.11" \
+      org.opencontainers.image.version="1.3.0" \
       org.opencontainers.image.authors="Pavel Shklovsky <pavel@cloudefined.com>" \
       org.opencontainers.image.source="https://github.com/pab1it0/prometheus-mcp-server" \
       org.opencontainers.image.licenses="MIT" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prometheus_mcp_server"
-version = "1.2.11"
+version = "1.3.0"
 description = "MCP server for Prometheus integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/pab1it0/prometheus-mcp-server",
     "source": "github"
   },
-  "version": "1.2.11",
+  "version": "1.3.0",
   "packages": [
     {
       "registry_type": "oci",
       "registry_base_url": "https://ghcr.io",
       "identifier": "pab1it0/prometheus-mcp-server",
-      "version": "1.2.11",
+      "version": "1.3.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
**Minor version bump** from 1.2.x to 1.3.0 introducing MCP registry deployment automation.

## 🆕 New Features
- **MCP Registry Deployment Integration**: Automated publishing to MCP registry on releases
- **Official MCP Publisher CLI**: Replaced non-working GitHub extension with official tooling

## Changes
- Updated version to **1.3.0** in:
  - pyproject.toml
  - server.json (both version fields)
  - Dockerfile (image label)

## Technical Details
- **Fixed MCP Publisher workflow** to use official CLI tool from MCP registry
- **Automated deployment** to MCP registry using GitHub OIDC authentication
- **Proper error handling** for registry publishing failures

## Why Minor Version?
This is a **minor version bump** (1.2.x → 1.3.0) because:
- ✅ **New feature**: MCP registry deployment automation
- ✅ **Enhanced CI/CD**: Improved deployment pipeline
- ✅ **No breaking changes**: Backward compatible

## Previous Issues Resolved
- Fixed deployment failures due to missing `gh-mcp-publish` extension
- Implemented proper MCP registry publishing workflow
- Enhanced release automation

## Test plan
- [x] Verify CI workflow syntax is valid
- [ ] Test complete deployment workflow after merge and tag
- [ ] Verify MCP registry publishing works correctly

Ready for merge and tagging with **v1.3.0**