### PR TITLE
ref #66 proper fix of get_metric_metadata

### DIFF
--- a/src/prometheus_mcp_server/server.py
+++ b/src/prometheus_mcp_server/server.py
@@ -270,8 +270,12 @@ async def get_metric_metadata(metric: str) -> List[Dict[str, Any]]:
     logger.info("Retrieving metric metadata", metric=metric)
     params = {"metric": metric}
     data = make_prometheus_request("metadata", params=params)
-    logger.info("Metric metadata retrieved", metric=metric, metadata_count=len(data))
-    return data
+    if "metadata" in data:
+        metadata = data["metadata"]
+    else:
+        metadata = data["data"]
+    logger.info("Metric metadata retrieved", metric=metric, metadata_count=len(metadata))
+    return metadata
 
 @mcp.tool(description="Get information about all scrape targets")
 async def get_targets() -> Dict[str, List[Dict[str, Any]]]:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -101,9 +101,9 @@ async def test_list_metrics(mock_make_request):
 async def test_get_metric_metadata(mock_make_request):
     """Test the get_metric_metadata tool."""
     # Setup
-    mock_make_request.return_value = [
+    mock_make_request.return_value = {"data": [
         {"metric": "up", "type": "gauge", "help": "Up indicates if the scrape was successful", "unit": ""}
-    ]
+    ]}
 
     async with Client(mcp) as client:
         # Execute


### PR DESCRIPTION
Hi, Pavel,

Previous fix of get_metric_metadata in https://github.com/pab1it0/prometheus-mcp-server/pull/76 is incorrect. You can check the corresponding URL of metadata to see how the data looks like:
http://<prometheus ip address>:9090/api/v1/metadata