### PR TITLE
fix: resolve Claude Code action OIDC authentication failures

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,9 +11,8 @@ on:
     #   - "src/**/*.jsx"
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
-  issues: write
   id-token: write
   actions: read
 
@@ -27,9 +26,8 @@ jobs:
     
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
-      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     
@@ -45,16 +43,13 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-
-          # This is an optional setting that allows Claude to read CI results on PRs
-          additional_permissions: |
-            actions: read
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
           # model: "claude-opus-4-1-20250805"
 
-          # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
+          # Prompt for automated review (no @claude mention needed)
+          prompt: |
             Please review this pull request and provide feedback on:
             - Code quality and best practices
             - Potential bugs or issues

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,7 +19,7 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
       issues: write
       id-token: write
@@ -35,10 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-
-          # This is an optional setting that allows Claude to read CI results on PRs
-          additional_permissions: |
-            actions: read
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
           # model: "claude-opus-4-1-20250805"


### PR DESCRIPTION
## Problem

The Claude Code Review action has been consistently failing with OIDC authentication errors across all pull requests:

```
Failed to setup GitHub token: Error: Invalid OIDC token
```

This prevented automated code reviews from functioning, affecting PRs from both same-repo and forked sources.

## Root Cause Analysis

After comprehensive investigation comparing our configuration with [official Anthropic documentation](https://github.com/anthropics/claude-code-action), I identified **three critical issues**:

### 1. Invalid Parameter Name ❌
**Issue:** Using `direct_prompt` instead of `prompt`
- The [action.yml](https://github.com/anthropics/claude-code-action/blob/main/action.yml) only defines `prompt` as a valid input parameter
- Was causing "invalid input parameter" warning
- **Fix:** Renamed parameter from `direct_prompt:` to `prompt:`

### 2. Missing Explicit GitHub Token 🔐
**Issue:** OIDC authentication failing for `pull_request_target` event
- Error: "Failed to setup GitHub token: Error: Invalid OIDC token"
- **Root Cause:** When using `pull_request_target`, OIDC doesn't auto-generate tokens; requires explicit `github_token` parameter
- The error message itself suggested: "If you instead wish to use this action with a custom GitHub token... provide a `github_token`"
- **Fix:** Added `github_token: ${{ secrets.GITHUB_TOKEN }}`

### 3. Configuration Drift from Official Examples 📋
**Issue:** Permissions and parameters don't match official working examples
- Using `contents: write` instead of recommended `read`
- Including unsupported `additional_permissions` block
- Extra `issues: write` in automated PR review workflow
- **Fix:** Aligned with [pr-review-comprehensive.yml](https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-comprehensive.yml)

## Changes Made

### `.github/workflows/claude-code-review.yml`
Automated PR review workflow updates:
- ✅ Changed `direct_prompt` → `prompt` parameter
- ✅ Added `github_token: ${{ secrets.GITHUB_TOKEN }}`
- ✅ Changed `contents: write` → `read` (workflow & job level)
- ✅ Removed `issues: write` permission (not needed)
- ✅ Removed invalid `additional_permissions` block

### `.github/workflows/claude.yml`
Interactive @claude mentions workflow updates:
- ✅ Added `github_token: ${{ secrets.GITHUB_TOKEN }}`
- ✅ Changed `contents: write` → `read`
- ✅ Kept `issues: write` (required for issue comments)
- ✅ Removed invalid `additional_permissions` block

## Verification Sources

All changes verified against official documentation:
- ✅ [Official PR Review Example](https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-comprehensive.yml)
- ✅ [Action Schema Definition](https://github.com/anthropics/claude-code-action/blob/main/action.yml)
- ✅ [Setup Documentation](https://github.com/anthropics/claude-code-action/blob/main/docs/setup.md)
- ✅ [Claude Code GitHub Actions Docs](https://docs.claude.com/en/docs/claude-code/github-actions)

## Expected Results

After merging this PR:
- ✅ OIDC authentication works correctly
- ✅ Claude successfully posts automated review comments
- ✅ Works with forked repository PRs (via `pull_request_target`)
- ✅ Works with same-repository PRs
- ✅ No "invalid input parameter" warnings
- ✅ Configuration matches official recommendations

## Testing Plan

1. **Merge this PR** to update workflows in main branch
2. **Test on PR #89** (existing test PR will automatically re-run with updated config)
3. **Verify** Claude Code Review posts comments without errors
4. **Confirm** no OIDC authentication failures in workflow logs

## Related Issues

Fixes #84 (Original OIDC error report on forked PR)
Supersedes #88 (Previous incomplete fix attempt)

---

**Note:** This PR consolidates all necessary fixes into a single, comprehensive solution based on official Anthropic documentation and working examples.