### PR TITLE
chore: bump version to 1.4.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ CMD ["/app/.venv/bin/prometheus-mcp-server"]
 
 LABEL org.opencontainers.image.title="Prometheus MCP Server" \
       org.opencontainers.image.description="Model Context Protocol server for Prometheus integration, enabling AI assistants to query metrics and monitor system health" \
-      org.opencontainers.image.version="1.4.1" \
+      org.opencontainers.image.version="1.4.2" \
       org.opencontainers.image.authors="Pavel Shklovsky <pavel@cloudefined.com>" \
       org.opencontainers.image.source="https://github.com/pab1it0/prometheus-mcp-server" \
       org.opencontainers.image.licenses="MIT" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prometheus_mcp_server"
-version = "1.4.1"
+version = "1.4.2"
 description = "MCP server for Prometheus integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
   "name": "io.github.pab1it0/prometheus-mcp-server",
   "description": "MCP server providing Prometheus metrics access and PromQL query execution for AI assistants",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "repository": {
     "url": "https://github.com/pab1it0/prometheus-mcp-server",
     "source": "github"
@@ -13,7 +13,7 @@
       "registryType": "oci",
       "registryBaseUrl": "https://ghcr.io",
       "identifier": "pab1it0/prometheus-mcp-server",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
Bump version from 1.4.1 to 1.4.2 in all relevant configuration files.

## Changes
- Updated version in `pyproject.toml`
- Updated version in `server.json` (2 occurrences)
- Updated version in `Dockerfile` (OCI image label)

## Context
The v1.4.2 tag was previously deleted and this PR prepares for a clean v1.4.2 release.