### PR TITLE
fix(server): prevent ctx from being exposed as a tool argument

### DIFF
--- a/src/prometheus_mcp_server/server.py
+++ b/src/prometheus_mcp_server/server.py
@@ -10,7 +10,7 @@ from enum import Enum
 
 import dotenv
 import requests
-from fastmcp import FastMCP
+from fastmcp import FastMCP, Context
 from prometheus_mcp_server.logging_config import get_logger
 
 dotenv.load_dotenv()
@@ -288,7 +288,7 @@ async def execute_query(query: str, time: Optional[str] = None) -> Dict[str, Any
         "openWorldHint": True
     }
 )
-async def execute_range_query(query: str, start: str, end: str, step: str, ctx=None) -> Dict[str, Any]:
+async def execute_range_query(query: str, start: str, end: str, step: str, ctx: Context | None = None) -> Dict[str, Any]:
     """Execute a range query against Prometheus.
     
     Args:
@@ -360,7 +360,7 @@ async def execute_range_query(query: str, start: str, end: str, step: str, ctx=N
         "openWorldHint": True
     }
 )
-async def list_metrics(ctx=None) -> List[str]:
+async def list_metrics(ctx: Context | None = None) -> List[str]:
     """Retrieve a list of all metric names available in Prometheus.
 
     Returns:


### PR DESCRIPTION
Bug: The ctx parameter was surfacing in the tool JSON schema and showing up as a user-facing argument. This happened because it was typed as an untyped None, leading FastMCP to treat it as a normal parameter.

Change: Annotate ctx as `Context | None` in the `execute_range_query` and `list_metrics` tools.

Effect: FastMCP recognizes ctx as an internal context object and removes it from the tool schema, keeping it behind the scenes while still enabling progress reporting. This fixes OpenAI model integrations that were receiving an unexpected ctx argument with no type leading to schema validation errors.

No runtime logic changes.