### PR TITLE
feature: add PROMETHEUS_DISABLE_LINKS config option

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,7 +1,9 @@
 # Prometheus configuration
 PROMETHEUS_URL=http://your-prometheus-server:9090
 # Set to false to disable SSL verification
-PROMETHEUS_URL_SSL_VERIFY=True 
+PROMETHEUS_URL_SSL_VERIFY=True
+# Set to true to disable Prometheus UI links in query results (saves context tokens)
+PROMETHEUS_DISABLE_LINKS=False
 
 # Authentication (if needed)
 # Choose one of the following authentication methods (if required):

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ docker run -i --rm \
 |----------|-------------|----------|
 | `PROMETHEUS_URL` | URL of your Prometheus server | Yes |
 | `PROMETHEUS_URL_SSL_VERIFY` | Set to False to disable SSL verification | No |
+| `PROMETHEUS_DISABLE_LINKS` | Set to True to disable Prometheus UI links in query results (saves context tokens) | No |
 | `PROMETHEUS_USERNAME` | Username for basic authentication | No |
 | `PROMETHEUS_PASSWORD` | Password for basic authentication | No |
 | `PROMETHEUS_TOKEN` | Bearer token for authentication | No |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,6 +50,7 @@ If multiple authentication methods are configured, the server will prioritize th
 | `PROMETHEUS_MCP_SERVER_TRANSPORT` | Choose between these transports: `http`, `stdio`, `sse`. If undefined,  `stdio` is set as the default transport. | `http` |
 | `PROMETHEUS_MCP_BIND_HOST` | Define the host for your MCP server, if undefined, `127.0.0.1` is set by default. | `localhost` |
 | `PROMETHEUS_MCP_BIND_PORT` | Define the port where your MCP server is exposed, if undefined, `8080` is set by default. | `8080` |
+| `PROMETHEUS_DISABLE_LINKS` | Disable Prometheus UI links in query results, if undefined, `False` is set by default. | `True` |
 
 ## MCP Client Configuration
 

--- a/server.json
+++ b/server.json
@@ -33,6 +33,13 @@
           "isSecret": false
         },
         {
+          "name": "PROMETHEUS_DISABLE_LINKS",
+          "description": "Set to True to disable Prometheus UI links in query results (saves context tokens in MCP clients)",
+          "isRequired": false,
+          "format": "boolean",
+          "isSecret": false
+        },
+        {
           "name": "PROMETHEUS_USERNAME",
           "description": "Username for Prometheus basic authentication",
           "isRequired": false,

--- a/src/prometheus_mcp_server/server.py
+++ b/src/prometheus_mcp_server/server.py
@@ -114,6 +114,7 @@ class MCPServerConfig:
 class PrometheusConfig:
     url: str
     url_ssl_verify: bool = True
+    disable_prometheus_links: bool = False
     # Optional credentials
     username: Optional[str] = None
     password: Optional[str] = None
@@ -126,6 +127,7 @@ class PrometheusConfig:
 config = PrometheusConfig(
     url=os.environ.get("PROMETHEUS_URL", ""),
     url_ssl_verify=os.environ.get("PROMETHEUS_URL_SSL_VERIFY", "True").lower() in ("true", "1", "yes"),
+    disable_prometheus_links=os.environ.get("PROMETHEUS_DISABLE_LINKS", "False").lower() in ("true", "1", "yes"),
     username=os.environ.get("PROMETHEUS_USERNAME", ""),
     password=os.environ.get("PROMETHEUS_PASSWORD", ""),
     token=os.environ.get("PROMETHEUS_TOKEN", ""),
@@ -254,22 +256,22 @@ async def execute_query(query: str, time: Optional[str] = None) -> Dict[str, Any
     logger.info("Executing instant query", query=query, time=time)
     data = make_prometheus_request("query", params=params)
 
-    # Build Prometheus UI link
-    from urllib.parse import urlencode
-    ui_params = {"g0.expr": query, "g0.tab": "0"}
-    if time:
-        ui_params["g0.moment_input"] = time
-    prometheus_ui_link = f"{config.url.rstrip('/')}/graph?{urlencode(ui_params)}"
-
     result = {
         "resultType": data["resultType"],
-        "result": data["result"],
-        "links": [{
+        "result": data["result"]
+    }
+
+    if not config.disable_prometheus_links:
+        from urllib.parse import urlencode
+        ui_params = {"g0.expr": query, "g0.tab": "0"}
+        if time:
+            ui_params["g0.moment_input"] = time
+        prometheus_ui_link = f"{config.url.rstrip('/')}/graph?{urlencode(ui_params)}"
+        result["links"] = [{
             "href": prometheus_ui_link,
             "rel": "prometheus-ui",
             "title": "View in Prometheus UI"
         }]
-    }
 
     logger.info("Instant query completed",
                 query=query,
@@ -319,25 +321,25 @@ async def execute_range_query(query: str, start: str, end: str, step: str, ctx=N
     if ctx:
         await ctx.report_progress(progress=50, total=100, message="Processing query results...")
 
-    # Build Prometheus UI link
-    from urllib.parse import urlencode
-    ui_params = {
-        "g0.expr": query,
-        "g0.tab": "0",
-        "g0.range_input": f"{start} to {end}",
-        "g0.step_input": step
-    }
-    prometheus_ui_link = f"{config.url.rstrip('/')}/graph?{urlencode(ui_params)}"
-
     result = {
         "resultType": data["resultType"],
-        "result": data["result"],
-        "links": [{
+        "result": data["result"]
+    }
+
+    if not config.disable_prometheus_links:
+        from urllib.parse import urlencode
+        ui_params = {
+            "g0.expr": query,
+            "g0.tab": "0",
+            "g0.range_input": f"{start} to {end}",
+            "g0.step_input": step
+        }
+        prometheus_ui_link = f"{config.url.rstrip('/')}/graph?{urlencode(ui_params)}"
+        result["links"] = [{
             "href": prometheus_ui_link,
             "rel": "prometheus-ui",
             "title": "View in Prometheus UI"
         }]
-    }
 
     # Report completion
     if ctx:


### PR DESCRIPTION
Adding an option to remove the `links` from responses saves a little bit of context (and lines of text to scroll past) for cases where the user isn't interested in links.

Thanks for developing this great MCP server!