### PR TITLE
feature: custom headers passing for each prometheus request.

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ docker run -i --rm \
 | `PROMETHEUS_MCP_SERVER_TRANSPORT` | Transport mode (stdio, http, sse) | No (default: stdio) |
 | `PROMETHEUS_MCP_BIND_HOST` | Host for HTTP transport | No (default: 127.0.0.1) |
 | `PROMETHEUS_MCP_BIND_PORT` | Port for HTTP transport | No (default: 8080) |
-
+| `PROMETHEUS_CUSTOM_HEADERS` | Custom headers as JSON string | No |
 
 ## Development
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,6 +18,12 @@ The server is configured primarily through environment variables. These can be s
 |----------|-------------|--------|
 | `PROMETHEUS_URL_SSL_VERIFY` | Set to False to disable SSL verification | `True` |
 
+### Optional headers for Prometheus requests
+
+| Variable | Description | Example |
+|----------|-------------|--------|
+| `PROMETHEUS_CUSTOM_HEADERS` | Custom headers to include in requests to Prometheus, formatted as a JSON string | `{"X-Custom-Header": "value"}` |
+
 ### Authentication Variables
 
 Prometheus MCP Server supports multiple authentication methods. Choose the appropriate one for your Prometheus setup:

--- a/src/prometheus_mcp_server/server.py
+++ b/src/prometheus_mcp_server/server.py
@@ -124,6 +124,8 @@ class PrometheusConfig:
     org_id: Optional[str] = None
     # Optional Custom MCP Server Configuration
     mcp_server_config: Optional[MCPServerConfig] = None
+    # Optional custom headers for Prometheus requests
+    custom_headers: Optional[Dict[str, str]] = None
 
 config = PrometheusConfig(
     url=os.environ.get("PROMETHEUS_URL", ""),
@@ -137,7 +139,8 @@ config = PrometheusConfig(
         mcp_server_transport=os.environ.get("PROMETHEUS_MCP_SERVER_TRANSPORT", "stdio").lower(),
         mcp_bind_host=os.environ.get("PROMETHEUS_MCP_BIND_HOST", "127.0.0.1"),
         mcp_bind_port=int(os.environ.get("PROMETHEUS_MCP_BIND_PORT", "8080"))
-    )
+    ),
+    custom_headers=json.loads(os.environ.get("PROMETHEUS_CUSTOM_HEADERS")) if os.environ.get("PROMETHEUS_CUSTOM_HEADERS") else None,
 )
 
 def get_prometheus_auth():
@@ -169,9 +172,12 @@ def make_prometheus_request(endpoint, params=None):
     if config.org_id:
         headers["X-Scope-OrgID"] = config.org_id
 
+    if config.custom_headers:
+        headers.update(config.custom_headers)
+
     try:
-        logger.debug("Making Prometheus API request", endpoint=endpoint, url=url, params=params)
-        
+        logger.debug("Making Prometheus API request", endpoint=endpoint, url=url, params=params, headers=headers)
+
         # Make the request with appropriate headers and auth
         response = requests.get(url, params=params, auth=auth, headers=headers, verify=url_ssl_verify)
         

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -272,3 +272,235 @@ def test_make_prometheus_request_ssl_verify_false(mock_get, mock_response):
     # Verify
     mock_get.assert_called_once()
     assert result == {"resultType": "vector", "result": []}
+
+@patch("prometheus_mcp_server.server.requests.get")
+def test_make_prometheus_request_with_custom_headers(mock_get, mock_response):
+    """Test making a request with custom headers."""
+    # Setup
+    mock_get.return_value = mock_response
+    config.url = "http://test:9090"
+    original_custom_headers = config.custom_headers
+    config.custom_headers = {"X-Custom-Header": "custom-value"}
+
+    # Execute
+    result = make_prometheus_request("query", {"query": "up"})
+
+    # Verify
+    mock_get.assert_called_once()
+    assert result == {"resultType": "vector", "result": []}
+
+    # Check that custom header was included
+    call_args = mock_get.call_args
+    headers = call_args[1]['headers']
+    assert 'X-Custom-Header' in headers
+    assert headers['X-Custom-Header'] == 'custom-value'
+
+    # Cleanup
+    config.custom_headers = original_custom_headers
+
+@patch("prometheus_mcp_server.server.requests.get")
+def test_make_prometheus_request_with_multiple_custom_headers(mock_get, mock_response):
+    """Test making a request with multiple custom headers."""
+    # Setup
+    mock_get.return_value = mock_response
+    config.url = "http://test:9090"
+    original_custom_headers = config.custom_headers
+    config.custom_headers = {
+        "X-Custom-Header-1": "value1",
+        "X-Custom-Header-2": "value2",
+        "X-Environment": "test"
+    }
+
+    # Execute
+    result = make_prometheus_request("query", {"query": "up"})
+
+    # Verify
+    mock_get.assert_called_once()
+    assert result == {"resultType": "vector", "result": []}
+
+    # Check that all custom headers were included
+    call_args = mock_get.call_args
+    headers = call_args[1]['headers']
+    assert 'X-Custom-Header-1' in headers
+    assert headers['X-Custom-Header-1'] == 'value1'
+    assert 'X-Custom-Header-2' in headers
+    assert headers['X-Custom-Header-2'] == 'value2'
+    assert 'X-Environment' in headers
+    assert headers['X-Environment'] == 'test'
+
+    # Cleanup
+    config.custom_headers = original_custom_headers
+
+@patch("prometheus_mcp_server.server.requests.get")
+def test_make_prometheus_request_with_custom_headers_and_token_auth(mock_get, mock_response):
+    """Test making a request with custom headers combined with token authentication."""
+    # Setup
+    mock_get.return_value = mock_response
+    config.url = "http://test:9090"
+    original_custom_headers = config.custom_headers
+    config.custom_headers = {"X-Custom-Header": "custom-value"}
+    config.token = "token123"
+    config.username = ""
+    config.password = ""
+
+    # Execute
+    result = make_prometheus_request("query", {"query": "up"})
+
+    # Verify
+    mock_get.assert_called_once()
+    assert result == {"resultType": "vector", "result": []}
+
+    # Check that both Authorization and custom headers were included
+    call_args = mock_get.call_args
+    headers = call_args[1]['headers']
+    assert 'Authorization' in headers
+    assert headers['Authorization'] == 'Bearer token123'
+    assert 'X-Custom-Header' in headers
+    assert headers['X-Custom-Header'] == 'custom-value'
+
+    # Cleanup
+    config.custom_headers = original_custom_headers
+    config.token = ""
+
+@patch("prometheus_mcp_server.server.requests.get")
+def test_make_prometheus_request_with_custom_headers_and_org_id(mock_get, mock_response):
+    """Test making a request with custom headers combined with org_id."""
+    # Setup
+    mock_get.return_value = mock_response
+    config.url = "http://test:9090"
+    original_custom_headers = config.custom_headers
+    original_org_id = config.org_id
+    config.custom_headers = {"X-Custom-Header": "custom-value"}
+    config.org_id = "test-org"
+
+    # Execute
+    result = make_prometheus_request("query", {"query": "up"})
+
+    # Verify
+    mock_get.assert_called_once()
+    assert result == {"resultType": "vector", "result": []}
+
+    # Check that both org_id and custom headers were included
+    call_args = mock_get.call_args
+    headers = call_args[1]['headers']
+    assert 'X-Scope-OrgID' in headers
+    assert headers['X-Scope-OrgID'] == 'test-org'
+    assert 'X-Custom-Header' in headers
+    assert headers['X-Custom-Header'] == 'custom-value'
+
+    # Cleanup
+    config.custom_headers = original_custom_headers
+    config.org_id = original_org_id
+
+@patch("prometheus_mcp_server.server.requests.get")
+def test_make_prometheus_request_with_empty_custom_headers(mock_get, mock_response):
+    """Test making a request with empty custom headers dictionary."""
+    # Setup
+    mock_get.return_value = mock_response
+    config.url = "http://test:9090"
+    original_custom_headers = config.custom_headers
+    config.custom_headers = {}
+
+    # Execute
+    result = make_prometheus_request("query", {"query": "up"})
+
+    # Verify
+    mock_get.assert_called_once()
+    assert result == {"resultType": "vector", "result": []}
+
+    # Cleanup
+    config.custom_headers = original_custom_headers
+
+@patch("prometheus_mcp_server.server.requests.get")
+def test_make_prometheus_request_with_none_custom_headers(mock_get, mock_response):
+    """Test making a request with None custom headers."""
+    # Setup
+    mock_get.return_value = mock_response
+    config.url = "http://test:9090"
+    original_custom_headers = config.custom_headers
+    config.custom_headers = None
+
+    # Execute
+    result = make_prometheus_request("query", {"query": "up"})
+
+    # Verify
+    mock_get.assert_called_once()
+    assert result == {"resultType": "vector", "result": []}
+
+    # Cleanup
+    config.custom_headers = original_custom_headers
+
+@patch("prometheus_mcp_server.server.requests.get")
+def test_make_prometheus_request_with_custom_headers_and_basic_auth(mock_get, mock_response):
+    """Test making a request with custom headers combined with basic authentication."""
+    # Setup
+    mock_get.return_value = mock_response
+    config.url = "http://test:9090"
+    original_custom_headers = config.custom_headers
+    config.custom_headers = {"X-Custom-Header": "custom-value"}
+    config.username = "user"
+    config.password = "pass"
+    config.token = ""
+
+    # Execute
+    result = make_prometheus_request("query", {"query": "up"})
+
+    # Verify
+    mock_get.assert_called_once()
+    assert result == {"resultType": "vector", "result": []}
+
+    # Check that custom headers were included (basic auth is passed separately)
+    call_args = mock_get.call_args
+    headers = call_args[1]['headers']
+    assert 'X-Custom-Header' in headers
+    assert headers['X-Custom-Header'] == 'custom-value'
+    # Basic auth should be in the auth parameter, not headers
+    auth = call_args[1]['auth']
+    assert auth is not None
+
+    # Cleanup
+    config.custom_headers = original_custom_headers
+    config.username = ""
+    config.password = ""
+
+@patch("prometheus_mcp_server.server.requests.get")
+def test_make_prometheus_request_with_all_headers_combined(mock_get, mock_response):
+    """Test making a request with custom headers, org_id, and token auth all combined."""
+    # Setup
+    mock_get.return_value = mock_response
+    config.url = "http://test:9090"
+    original_custom_headers = config.custom_headers
+    original_org_id = config.org_id
+    config.custom_headers = {
+        "X-Custom-Header-1": "value1",
+        "X-Custom-Header-2": "value2"
+    }
+    config.org_id = "test-org"
+    config.token = "token123"
+    config.username = ""
+    config.password = ""
+
+    # Execute
+    result = make_prometheus_request("query", {"query": "up"})
+
+    # Verify
+    mock_get.assert_called_once()
+    assert result == {"resultType": "vector", "result": []}
+
+    # Check that all headers were included
+    call_args = mock_get.call_args
+    headers = call_args[1]['headers']
+    assert 'Authorization' in headers
+    assert headers['Authorization'] == 'Bearer token123'
+    assert 'X-Scope-OrgID' in headers
+    assert headers['X-Scope-OrgID'] == 'test-org'
+    assert 'X-Custom-Header-1' in headers
+    assert headers['X-Custom-Header-1'] == 'value1'
+    assert 'X-Custom-Header-2' in headers
+    assert headers['X-Custom-Header-2'] == 'value2'
+
+    # Cleanup
+    config.custom_headers = original_custom_headers
+    config.org_id = original_org_id
+    config.token = ""
+


### PR DESCRIPTION
Hi @pab1it0!

Thanks for awesome project! It really helps. I hit the wall because in my org prometheus is behind ZTA, so in order to make requests to it - you need to provide custom header or to have special proxy (what it lazy). So I did it in this small PR >

Please review, argue, come back with with feedback or like :)

TY