### PR TITLE
Add configurable timeout to all Prometheus HTTP requests to prevent resource exhaustion

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -4,6 +4,8 @@ PROMETHEUS_URL=http://your-prometheus-server:9090
 PROMETHEUS_URL_SSL_VERIFY=True
 # Set to true to disable Prometheus UI links in query results (saves context tokens)
 PROMETHEUS_DISABLE_LINKS=False
+# Request timeout in seconds to prevent hanging requests (DDoS protection, default: 30)
+PROMETHEUS_REQUEST_TIMEOUT=30
 
 # Authentication (if needed)
 # Choose one of the following authentication methods (if required):

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ docker run -i --rm \
 | `PROMETHEUS_URL` | URL of your Prometheus server | Yes |
 | `PROMETHEUS_URL_SSL_VERIFY` | Set to False to disable SSL verification | No |
 | `PROMETHEUS_DISABLE_LINKS` | Set to True to disable Prometheus UI links in query results (saves context tokens) | No |
+| `PROMETHEUS_REQUEST_TIMEOUT` | Request timeout in seconds to prevent hanging requests (DDoS protection) | No (default: 30) |
 | `PROMETHEUS_USERNAME` | Username for basic authentication | No |
 | `PROMETHEUS_PASSWORD` | Password for basic authentication | No |
 | `PROMETHEUS_TOKEN` | Bearer token for authentication | No |

--- a/src/prometheus_mcp_server/server.py
+++ b/src/prometheus_mcp_server/server.py
@@ -126,6 +126,8 @@ class PrometheusConfig:
     mcp_server_config: Optional[MCPServerConfig] = None
     # Optional custom headers for Prometheus requests
     custom_headers: Optional[Dict[str, str]] = None
+    # Request timeout in seconds to prevent hanging requests (DDoS protection)
+    request_timeout: int = 30
 
 config = PrometheusConfig(
     url=os.environ.get("PROMETHEUS_URL", ""),
@@ -141,6 +143,7 @@ config = PrometheusConfig(
         mcp_bind_port=int(os.environ.get("PROMETHEUS_MCP_BIND_PORT", "8080"))
     ),
     custom_headers=json.loads(os.environ.get("PROMETHEUS_CUSTOM_HEADERS")) if os.environ.get("PROMETHEUS_CUSTOM_HEADERS") else None,
+    request_timeout=int(os.environ.get("PROMETHEUS_REQUEST_TIMEOUT", "30")),
 )
 
 def get_prometheus_auth():
@@ -176,11 +179,11 @@ def make_prometheus_request(endpoint, params=None):
         headers.update(config.custom_headers)
 
     try:
-        logger.debug("Making Prometheus API request", endpoint=endpoint, url=url, params=params, headers=headers)
+        logger.debug("Making Prometheus API request", endpoint=endpoint, url=url, params=params, headers=headers, timeout=config.request_timeout)
 
-        # Make the request with appropriate headers and auth
-        response = requests.get(url, params=params, auth=auth, headers=headers, verify=url_ssl_verify)
-        
+        # Make the request with appropriate headers, auth, and timeout (DDoS protection)
+        response = requests.get(url, params=params, auth=auth, headers=headers, verify=url_ssl_verify, timeout=config.request_timeout)
+
         response.raise_for_status()
         result = response.json()
         


### PR DESCRIPTION
Security fix: Added configurable timeout to all Prometheus HTTP requests to prevent resource exhaustion from hanging requests when the server is slow or unresponsive.

Changes:
- Added PROMETHEUS_REQUEST_TIMEOUT configuration (default: 30 seconds)
- Updated make_prometheus_request() to enforce timeout on all requests
- Prevents hanging requests on health_check, execute_range_query, and list_metrics endpoints
- Updated .env.template and README with new configuration option

This addresses potential DDoS vulnerability when MCP server runs on SSE/HTTP transport where malicious actors could cause resource exhaustion.