### PR TITLE
feat: add /health endpoint and enable stateless_http for multi-replic…

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -31,3 +31,4 @@ PROMETHEUS_TOKEN=your_token
 # Optional: Only relevant for non-stdio transports
 # PROMETHEUS_MCP_BIND_HOST=localhost # if undefined, 127.0.0.1 is set by default.
 # PROMETHEUS_MCP_BIND_PORT=8080 # if undefined, 8080 is set by default.
+# PROMETHEUS_MCP_STATELESS_HTTP=false # Enable stateless HTTP mode for multi-replica support.

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ See the [chart values](charts/prometheus-mcp-server/values.yaml) for all availab
 | `PROMETHEUS_MCP_SERVER_TRANSPORT` | Transport mode (stdio, http, sse) | No (default: stdio) |
 | `PROMETHEUS_MCP_BIND_HOST` | Host for HTTP transport | No (default: 127.0.0.1) |
 | `PROMETHEUS_MCP_BIND_PORT` | Port for HTTP transport | No (default: 8080) |
+| `PROMETHEUS_MCP_STATELESS_HTTP` | Enable stateless HTTP mode for multi-replica support | No (default: False) |
 | `PROMETHEUS_CUSTOM_HEADERS` | Custom headers as JSON string | No |
 | `TOOL_PREFIX` | Prefix for all tool names (e.g., `staging` results in `staging_execute_query`). Useful for running multiple instances targeting different environments in Cursor | No |
 

--- a/charts/prometheus-mcp-server/README.md
+++ b/charts/prometheus-mcp-server/README.md
@@ -58,6 +58,7 @@ When `auth.existingSecret` is set, the chart expects the Secret to contain the k
 |-----------|-------------|---------|
 | `mcp.transport` | Transport mode: `http`, `sse`, or `stdio` | `"http"` |
 | `mcp.bindHost` | Bind address | `"0.0.0.0"` |
+| `mcp.statelessHttp` | Enable stateless HTTP mode for multi-replica support | `false` |
 | `mcp.toolPrefix` | Prefix for all MCP tool names (e.g., `staging`) | `""` |
 
 ### Deployment

--- a/charts/prometheus-mcp-server/ci/full-values.yaml
+++ b/charts/prometheus-mcp-server/ci/full-values.yaml
@@ -14,6 +14,7 @@ auth:
 
 mcp:
   transport: "http"
+  statelessHttp: true
   toolPrefix: "staging"
 
 service:

--- a/charts/prometheus-mcp-server/templates/deployment.yaml
+++ b/charts/prometheus-mcp-server/templates/deployment.yaml
@@ -56,6 +56,10 @@ spec:
             - name: PROMETHEUS_CUSTOM_HEADERS
               value: {{ .Values.prometheus.customHeaders | quote }}
             {{- end }}
+            {{- if .Values.mcp.statelessHttp }}
+            - name: PROMETHEUS_MCP_STATELESS_HTTP
+              value: "true"
+            {{- end }}
             {{- if .Values.mcp.toolPrefix }}
             - name: TOOL_PREFIX
               value: {{ .Values.mcp.toolPrefix | quote }}

--- a/charts/prometheus-mcp-server/values.yaml
+++ b/charts/prometheus-mcp-server/values.yaml
@@ -98,14 +98,14 @@ containerSecurityContext:
 
 livenessProbe:
   httpGet:
-    path: /
+    path: /health
     port: http
   initialDelaySeconds: 10
   periodSeconds: 30
 
 readinessProbe:
   httpGet:
-    path: /
+    path: /health
     port: http
   initialDelaySeconds: 5
   periodSeconds: 10

--- a/charts/prometheus-mcp-server/values.yaml
+++ b/charts/prometheus-mcp-server/values.yaml
@@ -37,6 +37,8 @@ mcp:
   transport: "http"
   # Bind host
   bindHost: "0.0.0.0"
+  # Enable stateless HTTP mode for multi-replica support
+  statelessHttp: false
   # Tool name prefix
   toolPrefix: ""
 

--- a/server.json
+++ b/server.json
@@ -102,6 +102,13 @@
           "isSecret": false
         },
         {
+          "name": "PROMETHEUS_MCP_STATELESS_HTTP",
+          "description": "Enable stateless HTTP mode for multi-replica support (default: false)",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
           "name": "PROMETHEUS_CUSTOM_HEADERS",
           "description": "Custom headers as JSON string to include in Prometheus requests",
           "isRequired": false,

--- a/src/prometheus_mcp_server/main.py
+++ b/src/prometheus_mcp_server/main.py
@@ -74,7 +74,7 @@ def run_server():
 
     http_transports = [TransportType.HTTP.value, TransportType.SSE.value]
     if transport in http_transports:
-        mcp.run(transport=transport, host=mcp_config.mcp_bind_host, port=mcp_config.mcp_bind_port)
+        mcp.run(transport=transport, host=mcp_config.mcp_bind_host, port=mcp_config.mcp_bind_port, stateless_http=True)
         logger.info("Starting Prometheus MCP Server", 
                 transport=transport, 
                 host=mcp_config.mcp_bind_host,

--- a/src/prometheus_mcp_server/main.py
+++ b/src/prometheus_mcp_server/main.py
@@ -74,11 +74,17 @@ def run_server():
 
     http_transports = [TransportType.HTTP.value, TransportType.SSE.value]
     if transport in http_transports:
-        mcp.run(transport=transport, host=mcp_config.mcp_bind_host, port=mcp_config.mcp_bind_port, stateless_http=True)
-        logger.info("Starting Prometheus MCP Server", 
-                transport=transport, 
+        mcp.run(
+            transport=transport,
+            host=mcp_config.mcp_bind_host,
+            port=mcp_config.mcp_bind_port,
+            **({"stateless_http": True} if mcp_config.stateless_http else {})
+        )
+        logger.info("Starting Prometheus MCP Server",
+                transport=transport,
                 host=mcp_config.mcp_bind_host,
-                port=mcp_config.mcp_bind_port)
+                port=mcp_config.mcp_bind_port,
+                stateless_http=mcp_config.stateless_http)
     else:
         mcp.run(transport=transport)
         logger.info("Starting Prometheus MCP Server", transport=transport)

--- a/src/prometheus_mcp_server/server.py
+++ b/src/prometheus_mcp_server/server.py
@@ -26,6 +26,13 @@ def _tool_name(name: str) -> str:
 mcp_name = f"Prometheus MCP ({TOOL_PREFIX})" if TOOL_PREFIX else "Prometheus MCP"
 mcp = FastMCP(mcp_name)
 
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+@mcp.custom_route("/health", methods=["GET"])
+async def health_endpoint(request: Request) -> JSONResponse:
+    return JSONResponse({"status": "ok"})
+
 # Cache for metrics list to improve completion performance
 _metrics_cache = {"data": None, "timestamp": 0}
 _CACHE_TTL = 300  # 5 minutes

--- a/src/prometheus_mcp_server/server.py
+++ b/src/prometheus_mcp_server/server.py
@@ -124,6 +124,7 @@ class MCPServerConfig:
     mcp_server_transport: TransportType = None
     mcp_bind_host: str = None
     mcp_bind_port: int = None
+    stateless_http: bool = False
 
     def __post_init__(self):
         """Validate mcp configuration."""
@@ -166,7 +167,8 @@ config = PrometheusConfig(
     mcp_server_config=MCPServerConfig(
         mcp_server_transport=os.environ.get("PROMETHEUS_MCP_SERVER_TRANSPORT", "stdio").lower(),
         mcp_bind_host=os.environ.get("PROMETHEUS_MCP_BIND_HOST", "127.0.0.1"),
-        mcp_bind_port=int(os.environ.get("PROMETHEUS_MCP_BIND_PORT", "8080"))
+        mcp_bind_port=int(os.environ.get("PROMETHEUS_MCP_BIND_PORT", "8080")),
+        stateless_http=os.environ.get("PROMETHEUS_MCP_STATELESS_HTTP", "False").lower() in ("true", "1", "yes"),
     ),
     client_cert=os.environ.get("PROMETHEUS_CLIENT_CERT", "") or None,
     client_key=os.environ.get("PROMETHEUS_CLIENT_KEY", "") or None,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -259,3 +259,37 @@ def test_run_server_sse_transport(mock_config, mock_run, mock_setup):
 
     # Verify
     mock_run.assert_called_once_with(transport="sse", host="0.0.0.0", port=9090)
+
+@patch("prometheus_mcp_server.main.setup_environment")
+@patch("prometheus_mcp_server.main.mcp.run")
+@patch("prometheus_mcp_server.main.config")
+def test_run_server_http_transport_stateless(mock_config, mock_run, mock_setup):
+    """Test server run with HTTP transport and stateless_http enabled."""
+    mock_setup.return_value = True
+    mock_config.mcp_server_config = MCPServerConfig(
+        mcp_server_transport="http",
+        mcp_bind_host="localhost",
+        mcp_bind_port=8080,
+        stateless_http=True
+    )
+
+    run_server()
+
+    mock_run.assert_called_once_with(transport="http", host="localhost", port=8080, stateless_http=True)
+
+@patch("prometheus_mcp_server.main.setup_environment")
+@patch("prometheus_mcp_server.main.mcp.run")
+@patch("prometheus_mcp_server.main.config")
+def test_run_server_http_transport_not_stateless(mock_config, mock_run, mock_setup):
+    """Test server run with HTTP transport and stateless_http disabled (default)."""
+    mock_setup.return_value = True
+    mock_config.mcp_server_config = MCPServerConfig(
+        mcp_server_transport="http",
+        mcp_bind_host="localhost",
+        mcp_bind_port=8080,
+        stateless_http=False
+    )
+
+    run_server()
+
+    mock_run.assert_called_once_with(transport="http", host="localhost", port=8080)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -576,3 +576,17 @@ def test_make_prometheus_request_with_all_headers_combined(mock_get, mock_respon
     config.org_id = original_org_id
     config.token = ""
 
+
+def test_health_endpoint_returns_ok():
+    """Test that the /health HTTP endpoint returns status ok."""
+    from prometheus_mcp_server.server import health_endpoint
+    from unittest.mock import MagicMock
+
+    mock_request = MagicMock()
+    response = asyncio.run(health_endpoint(mock_request))
+
+    assert response.status_code == 200
+    import json
+    body = json.loads(response.body)
+    assert body == {"status": "ok"}
+


### PR DESCRIPTION
## Summary

- Add a dedicated `GET /health` HTTP endpoint returning `{"status": "ok"}`, giving Kubernetes liveness and
readiness probes a lightweight target that doesn't require a full MCP handshake.
- Update the Helm chart default probe paths from `/` to `/health` so probes work out of the box.
- Enable `stateless_http=True` on HTTP/SSE transports so multiple replicas can run concurrently without shared
  session state, allowing horizontal scaling in Kubernetes.

## Motivation

When deploying with the Helm chart and `replicaCount > 1`, two problems arise:

1. The default liveness/readiness probes hit `/` which is the MCP endpoint and not suitable as a health check
— causing probe failures and pods being killed.
2. Without `stateless_http=True`, FastMCP maintains session state that breaks request routing across replicas.

## Changes

- `src/prometheus_mcp_server/server.py`: register `/health` custom route via `@mcp.custom_route`
- `src/prometheus_mcp_server/main.py`: pass `stateless_http=True` to `mcp.run()` for HTTP/SSE transports
- `charts/prometheus-mcp-server/values.yaml`: update probe paths from `/` to `/health`

## Test plan

- [ ] Deploy with `replicaCount: 2` and verify probes pass
- [ ] Verify `GET /health` returns `{"status": "ok"}` with HTTP 200
- [ ] Verify MCP tools work correctly across replicas with `stateless_http=True`