### PR TITLE
chore: bump version to 1.6.1

### DIFF
--- a/.github/workflows/sync-version.yml
+++ b/.github/workflows/sync-version.yml
@@ -60,16 +60,22 @@ jobs:
           sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" src/prometheus_mcp_server/server.py
           echo "Updated server.py with version $VERSION"
 
+      - name: Update Chart.yaml
+        run: |
+          VERSION="${{ steps.get_version.outputs.version }}"
+          sed -i "s/^appVersion: \"[^\"]*\"/appVersion: \"$VERSION\"/" charts/prometheus-mcp-server/Chart.yaml
+          echo "Updated Chart.yaml with appVersion $VERSION"
+
       - name: Check for changes
         id: check_changes
         run: |
-          git diff --exit-code Dockerfile server.json src/prometheus_mcp_server/server.py || echo "changes=true" >> $GITHUB_OUTPUT
+          git diff --exit-code Dockerfile server.json src/prometheus_mcp_server/server.py charts/prometheus-mcp-server/Chart.yaml || echo "changes=true" >> $GITHUB_OUTPUT
 
       - name: Commit and push changes
         if: steps.check_changes.outputs.changes == 'true'
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git add Dockerfile server.json src/prometheus_mcp_server/server.py
+          git add Dockerfile server.json src/prometheus_mcp_server/server.py charts/prometheus-mcp-server/Chart.yaml
           git commit -m "chore: sync version to ${{ steps.get_version.outputs.version }}"
           git push

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ CMD ["/app/.venv/bin/prometheus-mcp-server"]
 
 LABEL org.opencontainers.image.title="Prometheus MCP Server" \
       org.opencontainers.image.description="Model Context Protocol server for Prometheus integration, enabling AI assistants to query metrics and monitor system health" \
-      org.opencontainers.image.version="1.6.1" \
+      org.opencontainers.image.version="1.6.0" \
       org.opencontainers.image.authors="Pavel Shklovsky <pavel@cloudefined.com>" \
       org.opencontainers.image.source="https://github.com/pab1it0/prometheus-mcp-server" \
       org.opencontainers.image.licenses="MIT" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ CMD ["/app/.venv/bin/prometheus-mcp-server"]
 
 LABEL org.opencontainers.image.title="Prometheus MCP Server" \
       org.opencontainers.image.description="Model Context Protocol server for Prometheus integration, enabling AI assistants to query metrics and monitor system health" \
-      org.opencontainers.image.version="1.6.0" \
+      org.opencontainers.image.version="1.6.1" \
       org.opencontainers.image.authors="Pavel Shklovsky <pavel@cloudefined.com>" \
       org.opencontainers.image.source="https://github.com/pab1it0/prometheus-mcp-server" \
       org.opencontainers.image.licenses="MIT" \

--- a/charts/prometheus-mcp-server/Chart.yaml
+++ b/charts/prometheus-mcp-server/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying the Prometheus MCP Server to Kubernetes
 type: application
 kubeVersion: ">=1.19.0-0"
 version: "1.0.0"
-appVersion: "1.6.1"
+appVersion: "1.6.0"
 home: https://github.com/pab1it0/prometheus-mcp-server
 sources:
   - https://github.com/pab1it0/prometheus-mcp-server

--- a/charts/prometheus-mcp-server/Chart.yaml
+++ b/charts/prometheus-mcp-server/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying the Prometheus MCP Server to Kubernetes
 type: application
 kubeVersion: ">=1.19.0-0"
 version: "1.0.0"
-appVersion: "1.6.0"
+appVersion: "1.6.1"
 home: https://github.com/pab1it0/prometheus-mcp-server
 sources:
   - https://github.com/pab1it0/prometheus-mcp-server

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prometheus_mcp_server"
-version = "1.6.0"
+version = "1.6.1"
 description = "MCP server for Prometheus integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.pab1it0/prometheus-mcp-server",
   "title": "Prometheus MCP Server",
   "description": "MCP server providing Prometheus metrics access and PromQL query execution for AI assistants",
-  "version": "1.6.1",
+  "version": "1.6.0",
   "repository": {
     "url": "https://github.com/pab1it0/prometheus-mcp-server",
     "source": "github"
@@ -12,7 +12,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/pab1it0/prometheus-mcp-server:1.6.1",
+      "identifier": "ghcr.io/pab1it0/prometheus-mcp-server:1.6.0",
       "transport": {
         "type": "stdio"
       },

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.pab1it0/prometheus-mcp-server",
   "title": "Prometheus MCP Server",
   "description": "MCP server providing Prometheus metrics access and PromQL query execution for AI assistants",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "repository": {
     "url": "https://github.com/pab1it0/prometheus-mcp-server",
     "source": "github"
@@ -12,7 +12,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/pab1it0/prometheus-mcp-server:1.6.0",
+      "identifier": "ghcr.io/pab1it0/prometheus-mcp-server:1.6.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/prometheus_mcp_server/server.py
+++ b/src/prometheus_mcp_server/server.py
@@ -68,7 +68,7 @@ async def health_check() -> Dict[str, Any]:
         health_status = {
             "status": "healthy",
             "service": "prometheus-mcp-server",
-            "version": "1.6.1",
+            "version": "1.6.0",
             "timestamp": datetime.utcnow().isoformat(),
             "transport": config.mcp_server_config.mcp_server_transport if config.mcp_server_config else "stdio",
             "configuration": {

--- a/src/prometheus_mcp_server/server.py
+++ b/src/prometheus_mcp_server/server.py
@@ -68,7 +68,7 @@ async def health_check() -> Dict[str, Any]:
         health_status = {
             "status": "healthy",
             "service": "prometheus-mcp-server",
-            "version": "1.6.0",
+            "version": "1.6.1",
             "timestamp": datetime.utcnow().isoformat(),
             "transport": config.mcp_server_config.mcp_server_transport if config.mcp_server_config else "stdio",
             "configuration": {


### PR DESCRIPTION
## Summary
- Bump patch version from 1.6.0 to 1.6.1 in `pyproject.toml`
- `Dockerfile`, `server.json`, and `src/prometheus_mcp_server/server.py` will be auto-synced by `.github/workflows/sync-version.yml`

## Test plan
- [ ] CI passes
- [ ] sync-version workflow updates downstream files