### PR TITLE
chore(chart): bump to 1.1.0 and require version bump in CI

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -23,6 +23,20 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Require Chart.yaml version bump when charts/ changes
+        if: github.event_name == 'pull_request'
+        run: |
+          base="origin/${{ github.base_ref }}"
+          git fetch --no-tags origin "${{ github.base_ref }}"
+          if git diff --name-only "$base"...HEAD -- charts/ | grep -q .; then
+            if ! git diff "$base"...HEAD -- charts/prometheus-mcp-server/Chart.yaml | grep -qE '^[+]version:'; then
+              echo "::error::charts/ changed but Chart.yaml 'version:' was not bumped. Bump it per SemVer (https://semver.org)."
+              exit 1
+            fi
+          fi
 
       - name: Set up Helm
         uses: azure/setup-helm@v4

--- a/charts/prometheus-mcp-server/Chart.yaml
+++ b/charts/prometheus-mcp-server/Chart.yaml
@@ -3,7 +3,7 @@ name: prometheus-mcp-server
 description: A Helm chart for deploying the Prometheus MCP Server to Kubernetes
 type: application
 kubeVersion: ">=1.19.0-0"
-version: "1.0.0"
+version: "1.1.0"
 appVersion: "1.6.1"
 home: https://github.com/pab1it0/prometheus-mcp-server
 sources:


### PR DESCRIPTION
## Summary

- Bump `charts/prometheus-mcp-server/Chart.yaml` `version` from `1.0.0` → `1.1.0`. The chart version was frozen at 1.0.0 even after #159 changed default probe paths (`/` → `/health`) and added the new `mcp.statelessHttp` value, so users on `helm upgrade` couldn't see a new chart release for those changes.
- Add a CI guard in `.github/workflows/helm-chart.yml` `lint-test` job: when any file under `charts/` changes on a PR, `Chart.yaml`'s `version:` field must also change, otherwise the job fails. Prevents the same regression.

## Why 1.1.0 (MINOR)

- Additive feature: `mcp.statelessHttp` (new value, default `false`, preserves prior behavior).
- Default-behavior change: probe paths default to `/health` instead of `/`. The previous default returned 404/406 to kubelet's plain HTTP probe — anyone successfully running with replicas was already overriding it, so this is effectively a fix to a broken default.

## Implementation notes

- Guard regex `^[+]version:` matches the new `version:` line in the diff and intentionally excludes `appVersion:`.
- `actions/checkout@v4` is bumped to `fetch-depth: 0` in `lint-test` so `git diff base...HEAD` has the history it needs. The `publish` job's checkout is unchanged.
- `appVersion` continues to be auto-synced from `pyproject.toml` by `sync-version.yml` — left intentionally decoupled from chart `version` so chart-only fixes don't require an app release.

## Test plan

- [ ] `helm lint` and `helm template` pass (existing CI steps cover this).
- [ ] On this PR, the new guard step passes (Chart.yaml's `version:` is bumped).
- [ ] Confirm the guard fails on a hypothetical PR that edits `charts/templates/*` without bumping `Chart.yaml`.
- [ ] After merge + next `v*` tag, verify a `prometheus-mcp-server-1.1.0.tgz` artifact appears in the OCI registry.