### PR TITLE
ci(helm): support chart-v* tags for chart-only releases

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches: ["main"]
     tags:
-      - 'v*'
+      - 'v*'         # app release tags — also re-publishes the chart at HEAD
+      - 'chart-v*'   # chart-only release tags, decoupled from app cadence
     paths:
       - 'charts/**'
   pull_request:
@@ -56,7 +57,7 @@ jobs:
 
   publish:
     name: Publish to OCI Registry
-    if: startsWith(github.ref, 'refs/tags/v') && github.event_name == 'push'
+    if: github.event_name == 'push' && github.ref_type == 'tag'
     needs: lint-test
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -67,6 +68,17 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Verify chart-v* tag matches Chart.yaml version
+        if: startsWith(github.ref, 'refs/tags/chart-v')
+        run: |
+          tag_version="${GITHUB_REF#refs/tags/chart-v}"
+          chart_version=$(grep '^version:' charts/prometheus-mcp-server/Chart.yaml | sed -E 's/^version: *"?([^"]*)"?$/\1/')
+          if [ "$tag_version" != "$chart_version" ]; then
+            echo "::error::tag chart-v$tag_version does not match Chart.yaml version $chart_version"
+            exit 1
+          fi
+          echo "tag chart-v$tag_version matches Chart.yaml version $chart_version"
 
       - name: Set up Helm
         uses: azure/setup-helm@v4


### PR DESCRIPTION
## Summary

Decouple chart releases from app releases. Previously the publish job in `.github/workflows/helm-chart.yml` was gated on `v*` tags only, so a chart-only fix (e.g. #159's probe-default change) had to wait for the next app `v*` tag before a new OCI artifact would publish to `ghcr.io/pab1it0/charts`. This is exactly what kept the published chart stuck at 1.0.0 after #159 and #162 merged.

## Changes

- Workflow `on.push.tags` now matches both `v*` and `chart-v*`.
- The `publish` job's gate switches from `startsWith(github.ref, 'refs/tags/v')` to `github.ref_type == 'tag'` — any tag that the workflow already filtered on (so `v*` OR `chart-v*`) is allowed to publish. Cleaner and avoids accidentally widening to non-version tags.
- New verification step on `chart-v*` tags: extracts the tag version from `\${GITHUB_REF#refs/tags/chart-v}` and compares to `Chart.yaml`'s `version:`. Fails the job on mismatch — prevents shipping `prometheus-mcp-server-1.2.0.tgz` under a `chart-v1.1.0` tag.

## Release flow after merge

| Scenario | Action | Resulting OCI artifact |
|---|---|---|
| App release | Bump `pyproject.toml` → tag `v\$X.\$Y.\$Z` (unchanged flow) | App image **and** chart at HEAD |
| Chart-only release | Bump `charts/.../Chart.yaml` `version`, merge, tag `chart-v\$X.\$Y.\$Z` | Chart only |

## Why both triggers (not chart-v* only)

Keeping `v*` as a trigger means app releases continue to re-publish the chart at HEAD — a safety net so a stale chart still gets re-packaged on app cadence. Removing it would be a separate, more opinionated change.

## Test plan

- [ ] Merge this PR.
- [ ] Push tag `chart-v1.1.0` (matches the current `Chart.yaml: version \"1.1.0\"` from #162).
- [ ] Verify the \`Helm Chart\` workflow runs \`Verify chart-v* tag matches Chart.yaml version\` and \`Push chart to OCI registry\`.
- [ ] Confirm \`prometheus-mcp-server-1.1.0.tgz\` appears at https://github.com/pab1it0/prometheus-mcp-server/pkgs/container/charts%2Fprometheus-mcp-server.
- [ ] (Optional, future) Test mismatch path by pushing \`chart-v9.9.9\` against current Chart.yaml — should fail at the verify step.