### PR TITLE
fix(docker): use /health endpoint in HEALTHCHECK for HTTP/SSE transports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD if [ "$PROMETHEUS_MCP_SERVER_TRANSPORT" = "http" ] || [ "$PROMETHEUS_MCP_SERVER_TRANSPORT" = "sse" ]; then \
-            curl -f http://localhost:${PROMETHEUS_MCP_BIND_PORT}/ >/dev/null 2>&1 || exit 1; \
+            curl -f http://localhost:${PROMETHEUS_MCP_BIND_PORT}/health >/dev/null 2>&1 || exit 1; \
         else \
             pgrep -f prometheus-mcp-server >/dev/null 2>&1 || exit 1; \
         fi


### PR DESCRIPTION
## Summary

- Update the Dockerfile `HEALTHCHECK` to probe `/health` instead of `/` when the server runs with HTTP or SSE transport.

## Motivation

PR #159 added a `GET /health` route and updated the Helm chart's liveness/readiness probe paths from `/` to `/health`, but the Dockerfile `HEALTHCHECK` was left pointing at `/`.

For users running the published image directly (e.g. `docker run`, Docker Compose, or any orchestrator that respects the image's baked-in `HEALTHCHECK`), this means containers using HTTP or SSE transport are always reported as unhealthy:

```
$ docker exec mcp-prometheus curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8080/
404
$ docker exec mcp-prometheus curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8080/health
200
```

`curl -f` treats 4xx as failure, so the existing check fails on every interval and Docker marks the container unhealthy after the retry budget runs out.

Helm users are unaffected because Kubernetes probes override the image `HEALTHCHECK` and PR #159 already fixed the chart defaults. stdio users are unaffected because the check branches to `pgrep` for that transport.

This avoid having to update my `compose.yaml` with a healthcheck:

```yaml
    healthcheck:
      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
      interval: 30s
      timeout: 10s
      start_period: 5s
      retries: 3
```

## Changes

- `Dockerfile`: change `curl -f http://localhost:${PROMETHEUS_MCP_BIND_PORT}/` to `.../health` inside the HTTP/SSE branch of the `HEALTHCHECK`.

## Test plan

- [x] Build image locally and run with `PROMETHEUS_MCP_SERVER_TRANSPORT=http`; verify `docker ps` reports `(healthy)` after the start period.
- [x] Confirm `curl -f http://localhost:8080/health` returns `200` from inside the container.
- [x] stdio transport still passes via the `pgrep` branch (unchanged).