### PR TITLE
Support dual stack support by default

### DIFF
--- a/charts/prometheus-mcp-server/values.yaml
+++ b/charts/prometheus-mcp-server/values.yaml
@@ -36,7 +36,7 @@ mcp:
   # Transport mode: http, sse, or stdio (use http or sse for Kubernetes)
   transport: "http"
   # Bind host
-  bindHost: "0.0.0.0"
+  bindHost: "::"
   # Enable stateless HTTP mode for multi-replica support
   statelessHttp: false
   # Tool name prefix


### PR DESCRIPTION
Helm defaults work on IPv4 only clusters