### PR TITLE
feat: add PROMETHEUS_MCP_ENABLED_TOOLS env var for server-side tool filtering

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -32,3 +32,9 @@ PROMETHEUS_TOKEN=your_token
 # PROMETHEUS_MCP_BIND_HOST=localhost # if undefined, 127.0.0.1 is set by default.
 # PROMETHEUS_MCP_BIND_PORT=8080 # if undefined, 8080 is set by default.
 # PROMETHEUS_MCP_STATELESS_HTTP=false # Enable stateless HTTP mode for multi-replica support.
+
+# Optional: server-side tool allowlist. Comma-separated list of tool base
+# names (case-insensitive). When unset or empty, all tools are registered
+# (default behaviour). Useful as defense-in-depth for downstream LLM agents
+# and for narrowing the surface across multi-consumer deployments. Example:
+# PROMETHEUS_MCP_ENABLED_TOOLS=execute_query,execute_range_query,list_metrics,get_metric_metadata

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ See the [chart values](charts/prometheus-mcp-server/values.yaml) for all availab
 | `PROMETHEUS_MCP_STATELESS_HTTP` | Enable stateless HTTP mode for multi-replica support | No (default: False) |
 | `PROMETHEUS_CUSTOM_HEADERS` | Custom headers as JSON string | No |
 | `TOOL_PREFIX` | Prefix for all tool names (e.g., `staging` results in `staging_execute_query`). Useful for running multiple instances targeting different environments in Cursor | No |
+| `PROMETHEUS_MCP_ENABLED_TOOLS` | Comma-separated allowlist of tool base names to register (e.g. `execute_query,list_metrics`). Names are matched case-insensitively against the unprefixed tool name, so the allowlist is stable across `TOOL_PREFIX` values. When unset or empty, every tool is registered (default behaviour). Useful as defense-in-depth for downstream LLM agents and for narrowing the surface across multi-consumer deployments | No |
 
 ## Available Tools
 
@@ -190,6 +191,20 @@ See the [chart values](charts/prometheus-mcp-server/values.yaml) for all availab
 | `get_targets` | Discovery | Get information about all scrape targets |
 
 The list of tools is configurable, so you can choose which tools you want to make available to the MCP client. This is useful if you don't use certain functionality or if you don't want to take up too much of the context window.
+
+To enforce an allowlist server-side (so every connected client only sees the
+narrowed surface), set `PROMETHEUS_MCP_ENABLED_TOOLS` to a comma-separated
+list of base tool names. For example, the following limits the server to the
+four read-only tools used by a typical LLM investigation agent:
+
+```bash
+PROMETHEUS_MCP_ENABLED_TOOLS=execute_query,execute_range_query,list_metrics,get_metric_metadata
+```
+
+Tools omitted from this list are simply not registered, so they will not
+appear in `list_tools` responses and cannot be invoked. Leaving the variable
+unset (or empty) preserves the default behaviour where every tool is
+registered.
 
 ## Features
 

--- a/src/prometheus_mcp_server/server.py
+++ b/src/prometheus_mcp_server/server.py
@@ -22,9 +22,45 @@ def _tool_name(name: str) -> str:
     """Build tool name with optional prefix."""
     return f"{TOOL_PREFIX}_{name}" if TOOL_PREFIX else name
 
+# Optional server-side tool allowlist. When PROMETHEUS_MCP_ENABLED_TOOLS is set
+# to a comma-separated list of tool base names (e.g.
+# "execute_query,list_metrics"), only those tools are registered. Names are
+# matched case-insensitively against the unprefixed tool name, so the allowlist
+# stays stable regardless of TOOL_PREFIX. When unset or empty, all tools are
+# registered (backward compatible). Useful as defense-in-depth for downstream
+# LLM agents and for narrowing the tool surface across multi-consumer
+# deployments.
+_enabled_tools_raw = os.environ.get("PROMETHEUS_MCP_ENABLED_TOOLS", "").strip()
+ENABLED_TOOLS: Optional[set] = (
+    {name.strip().lower() for name in _enabled_tools_raw.split(",") if name.strip()}
+    if _enabled_tools_raw
+    else None
+)
+
+def _tool_enabled(name: str) -> bool:
+    """Return True when the given (unprefixed) tool name should be registered."""
+    return ENABLED_TOOLS is None or name.lower() in ENABLED_TOOLS
+
 # Include prefix in MCP server name if set
 mcp_name = f"Prometheus MCP ({TOOL_PREFIX})" if TOOL_PREFIX else "Prometheus MCP"
 mcp = FastMCP(mcp_name)
+
+def _tool(*, name: str, **kwargs):
+    """Conditional ``mcp.tool`` decorator that honours PROMETHEUS_MCP_ENABLED_TOOLS.
+
+    The ``name`` argument is the (already-prefixed) tool name produced by
+    ``_tool_name(...)``. We strip the prefix back off before checking the
+    allowlist so the env var is always specified using the canonical base
+    names regardless of TOOL_PREFIX. When the tool is disabled we return a
+    no-op decorator so the underlying coroutine is left undefined for the MCP
+    server, effectively removing it from the surface.
+    """
+    base_name = name[len(TOOL_PREFIX) + 1:] if TOOL_PREFIX and name.startswith(f"{TOOL_PREFIX}_") else name
+    if _tool_enabled(base_name):
+        return mcp.tool(name=name, **kwargs)
+    def _skip(func):
+        return func
+    return _skip
 
 from starlette.requests import Request
 from starlette.responses import JSONResponse
@@ -46,7 +82,7 @@ def clear_metrics_cache():
 logger = get_logger()
 
 # Health check tool for Docker containers and monitoring
-@mcp.tool(
+@_tool(
     name=_tool_name("health_check"),
     description="Health check endpoint for container monitoring and status verification",
     annotations={
@@ -275,7 +311,7 @@ def get_cached_metrics() -> List[str]:
 # Note: Argument completions will be added when FastMCP supports the completion
 # capability. The get_cached_metrics() function above is ready for that integration.
 
-@mcp.tool(
+@_tool(
     name=_tool_name("execute_query"),
     description="Execute a PromQL instant query against Prometheus",
     annotations={
@@ -328,7 +364,7 @@ async def execute_query(query: str, time: Optional[str] = None) -> Dict[str, Any
 
     return result
 
-@mcp.tool(
+@_tool(
     name=_tool_name("execute_range_query"),
     description="Execute a PromQL range query with start time, end time, and step interval",
     annotations={
@@ -402,7 +438,7 @@ async def execute_range_query(query: str, start: str, end: str, step: str, ctx: 
 
     return result
 
-@mcp.tool(
+@_tool(
     name=_tool_name("list_metrics"),
     description="List all available metrics in Prometheus with optional pagination support",
     annotations={
@@ -543,7 +579,7 @@ def _metadata_matches_pattern(metric_name: str, entries: List[Dict[str, Any]], p
     return False
 
 
-@mcp.tool(
+@_tool(
     name=_tool_name("get_metric_metadata"),
     description=(
         "Get metadata (type, help, unit) for metrics. "
@@ -627,7 +663,7 @@ async def get_metric_metadata(
 
     return result
 
-@mcp.tool(
+@_tool(
     name=_tool_name("get_targets"),
     description="Get information about all scrape targets",
     annotations={

--- a/tests/test_enabled_tools.py
+++ b/tests/test_enabled_tools.py
@@ -1,0 +1,104 @@
+"""Tests for the PROMETHEUS_MCP_ENABLED_TOOLS server-side tool allowlist."""
+
+import asyncio
+import importlib
+import sys
+
+import pytest
+
+
+def _reload_server():
+    """Reimport prometheus_mcp_server.server so module-level env reads re-run."""
+    sys.modules.pop("prometheus_mcp_server.server", None)
+    return importlib.import_module("prometheus_mcp_server.server")
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Provide a clean PROMETHEUS_* env for each test and restore the original
+    prometheus_mcp_server.server module identity on teardown so other test
+    files (which import the module once and patch attributes on it) are not
+    affected by our reload."""
+    original_module = sys.modules.get("prometheus_mcp_server.server")
+    for key in (
+        "TOOL_PREFIX",
+        "PROMETHEUS_MCP_ENABLED_TOOLS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    # PROMETHEUS_URL just needs to be set so config builds successfully.
+    monkeypatch.setenv("PROMETHEUS_URL", "http://localhost:9090")
+    yield monkeypatch
+    if original_module is not None:
+        sys.modules["prometheus_mcp_server.server"] = original_module
+    else:
+        sys.modules.pop("prometheus_mcp_server.server", None)
+
+
+def _registered_tool_names(server_module):
+    return sorted(tool.name for tool in asyncio.run(server_module.mcp.list_tools()))
+
+
+def test_all_tools_registered_by_default(clean_env):
+    """When PROMETHEUS_MCP_ENABLED_TOOLS is unset, every tool is registered."""
+    server = _reload_server()
+
+    assert server.ENABLED_TOOLS is None
+    assert _registered_tool_names(server) == [
+        "execute_query",
+        "execute_range_query",
+        "get_metric_metadata",
+        "get_targets",
+        "health_check",
+        "list_metrics",
+    ]
+
+
+def test_enabled_tools_allowlist_filters_registry(clean_env):
+    """Only tools listed in PROMETHEUS_MCP_ENABLED_TOOLS are registered."""
+    clean_env.setenv(
+        "PROMETHEUS_MCP_ENABLED_TOOLS",
+        "execute_query,list_metrics",
+    )
+    server = _reload_server()
+
+    assert server.ENABLED_TOOLS == {"execute_query", "list_metrics"}
+    assert _registered_tool_names(server) == ["execute_query", "list_metrics"]
+
+
+def test_enabled_tools_is_case_and_whitespace_insensitive(clean_env):
+    """Allowlist matches base names case-insensitively and trims whitespace."""
+    clean_env.setenv(
+        "PROMETHEUS_MCP_ENABLED_TOOLS",
+        " EXECUTE_QUERY , Execute_Range_Query ,,list_metrics ",
+    )
+    server = _reload_server()
+
+    assert _registered_tool_names(server) == [
+        "execute_query",
+        "execute_range_query",
+        "list_metrics",
+    ]
+
+
+def test_enabled_tools_works_with_tool_prefix(clean_env):
+    """Allowlist is checked against the unprefixed base name."""
+    clean_env.setenv("TOOL_PREFIX", "staging")
+    clean_env.setenv(
+        "PROMETHEUS_MCP_ENABLED_TOOLS",
+        "execute_query,list_metrics",
+    )
+    server = _reload_server()
+
+    assert _registered_tool_names(server) == [
+        "staging_execute_query",
+        "staging_list_metrics",
+    ]
+
+
+def test_empty_enabled_tools_falls_back_to_all_tools(clean_env):
+    """An empty / whitespace-only env var is treated as 'no allowlist'."""
+    clean_env.setenv("PROMETHEUS_MCP_ENABLED_TOOLS", "   ")
+    server = _reload_server()
+
+    assert server.ENABLED_TOOLS is None
+    assert len(_registered_tool_names(server)) == 6


### PR DESCRIPTION
## Summary

Add an optional server-side tool allowlist via a new `PROMETHEUS_MCP_ENABLED_TOOLS` environment variable. When set to a comma-separated list of tool base names (e.g. `execute_query,list_metrics`), only those tools are registered; tools omitted from the list are not exposed in `list_tools` and cannot be invoked. When unset or empty, every tool is registered (default behaviour today).

Matching is case-insensitive against the unprefixed base name, so the allowlist is stable across `TOOL_PREFIX` values.

## Motivation

Defense-in-depth for downstream LLM agents and for narrowing the tool surface across multi-consumer deployments.

Concretely, we run this MCP behind a small fleet of LLM agents (one per investigation type). Each agent already passes an `allowed_tools` allowlist when wiring the MCP, but that filter is enforced in the agent layer only. Other clients connecting to the same MCP — Cursor, ad-hoc consumers, future agents — currently inherit the full surface. We want the narrowed surface enforced at the server too, so:

- New consumers fail closed rather than open.
- Upstream version bumps that introduce additional tools don't silently expand the surface for every connected client.
- Specific tools that are known-expensive in the LLM context (e.g. `get_targets`, which returns ~20 MiB on our cluster and blows past the model context window) can be hidden across all consumers from a single config knob.

`grafana/mcp-grafana` already ships an equivalent `--enabled-tools` flag and `opensearch-project/opensearch-mcp-server-py` ships an `OPENSEARCH_ENABLED_TOOLS` env var; this PR brings the same idiom to the Prometheus MCP.

## API

```bash
# Limit the server to the four read-only tools used by a typical investigation agent
PROMETHEUS_MCP_ENABLED_TOOLS=execute_query,execute_range_query,list_metrics,get_metric_metadata
```

- Comma-separated list of tool base names.
- Case-insensitive; surrounding whitespace and empty entries are ignored.
- Matched against the **unprefixed** name, so callers don't need to know whether `TOOL_PREFIX` is set.
- Unset / empty string preserves the current default: every `@mcp.tool` is registered.

## Implementation

- All six existing `@mcp.tool(name=_tool_name(...))` decorator sites now go through a thin `_tool()` wrapper.
- `_tool()` either delegates to `mcp.tool(...)` (when the tool is allowed or no allowlist is configured) or returns a no-op decorator (when the tool is filtered out, so it never gets registered).
- The allowlist is resolved once at module import. Setting `ENABLED_TOOLS = None` for unset / empty input means the runtime check is a single identity comparison in the hot path.

## Tests

`tests/test_enabled_tools.py` adds 5 focused tests:

- Default behaviour: all 6 tools registered when the env var is unset.
- Allowlist filters the registered set to exactly the named tools.
- Case-insensitive matching + whitespace tolerance + empty entries skipped.
- Works correctly together with `TOOL_PREFIX` (allowlist is checked against the unprefixed name).
- Empty / whitespace-only env var falls back to "all tools".

Full suite (`pytest --no-cov`) passes: 146 passed, 13 skipped.

## Docs

- `README.md` — new row in the configuration table + a paragraph + example under **Available Tools**.
- `.env.template` — commented-out example showing the typical investigation-agent allowlist.