### PR TITLE
feat: add alerts/rules, label/series exploration, and runtime status tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,14 @@ See the [chart values](charts/prometheus-mcp-server/values.yaml) for all availab
 | `list_metrics` | Discovery | List all available metrics in Prometheus with pagination and filtering support |
 | `get_metric_metadata` | Discovery | Get metadata for one metric or bulk metadata with optional filtering |
 | `get_targets` | Discovery | Get information about all scrape targets |
+| `list_label_names` | Discovery | List all label names, optionally restricted to matching series and a time range |
+| `list_label_values` | Discovery | List all values for a label, optionally restricted to matching series and a time range |
+| `find_series` | Discovery | Find time series matching label selectors, with optional time range and result limit |
+| `list_alerts` | Alerting | Get all active alerts with their state, labels, and annotations |
+| `list_rules` | Alerting | Get alerting and recording rules with their health, state, and evaluation info |
+| `get_runtime_info` | Status | Get Prometheus runtime information (start time, config reload status, goroutine count, storage retention) |
+| `get_build_info` | Status | Get Prometheus build information (version, revision, Go version) |
+| `get_tsdb_stats` | Status | Get TSDB cardinality statistics (head series counts, top metrics by series count) |
 
 The list of tools is configurable, so you can choose which tools you want to make available to the MCP client. This is useful if you don't use certain functionality or if you don't want to take up too much of the context window.
 

--- a/docs/superpowers/specs/2026-07-08-alerts-labels-status-tools-design.md
+++ b/docs/superpowers/specs/2026-07-08-alerts-labels-status-tools-design.md
@@ -1,0 +1,102 @@
+# Alerts/Rules, Label Exploration, and Runtime Status Tools
+
+**Date:** 2026-07-08
+**Status:** Approved
+
+## Goal
+
+Add three groups of read-only tools that close the biggest gaps for LLM-driven
+investigation: seeing what is firing, discovering labels to build valid PromQL, and
+inspecting the server itself.
+
+## Current state
+
+The server exposes 6 tools: `health_check`, `execute_query`, `execute_range_query`,
+`list_metrics`, `get_metric_metadata`, `get_targets`. All Prometheus API access goes through
+`make_prometheus_request(endpoint, params)` which unwraps the `{"status": "success", "data": ...}`
+envelope, handles auth/headers/TLS, and raises on errors.
+
+## Selected features
+
+### 1. Alerts & rules visibility
+
+The single biggest gap: an LLM investigating an incident cannot see what is firing.
+
+- **`list_alerts`** — `GET /api/v1/alerts`. No parameters. Returns `{"alerts": [...]}` plus a
+  computed `alert_count` for convenience.
+- **`list_rules`** — `GET /api/v1/rules`. Optional `type` parameter (`alert` | `record`,
+  validated before the request) passed through as `?type=`. Optional `rule_name` and `rule_group`
+  filters passed as repeated `rule_name[]` / `rule_group[]` params (server-side filtering,
+  supported since Prometheus 2.44) **and re-applied client-side**, because older Prometheus and
+  some compatible backends (Thanos, VictoriaMetrics) silently ignore the params — without the
+  fallback they would return unfiltered data presented as filtered.
+  Returns `{"groups": [...], "group_count": N}`.
+
+### 2. Label & series exploration
+
+`list_metrics` only exposes `__name__` values. LLMs need generic label discovery to construct
+valid PromQL.
+
+- **`list_label_names`** — `GET /api/v1/labels`. Optional `match` (list of series selectors,
+  sent as repeated `match[]`), optional `start`/`end` timestamps. Returns
+  `{"labels": [...], "count": N}` for consistency with the repo's dict-shaped tool results.
+- **`list_label_values`** — `GET /api/v1/label/{label_name}/values`. Same optional `match`,
+  `start`, `end`. Returns `{"values": [...], "count": N}`. `label_name` must be non-empty and is
+  escaped with Prometheus's `U__` values-escaping when it falls outside the classic
+  `[a-zA-Z_][a-zA-Z0-9_]*` charset (Prometheus 3.x UTF-8 names like `app.kubernetes.io/name`
+  contain `/` and would otherwise change the request path).
+- **`find_series`** — `GET /api/v1/series`. Required `match` (list of series selectors; the API
+  requires at least one), optional `start`/`end`, optional `limit` (must be positive). The limit
+  is forwarded server-side as `limit+1` (honored since Prometheus 2.53, harmlessly ignored by
+  older versions) so a broad selector on a high-cardinality server doesn't transfer the full
+  series set; the extra series only signals `has_more`. Returns `{"series": [...],
+  "returned_count": N, "has_more": bool}` — no exact `total_count`, which a bounded fetch cannot
+  know.
+
+### 3. Runtime & build diagnostics
+
+Lets an LLM answer "what version is this, how is it configured at runtime, and what is eating
+storage" without shell access.
+
+- **`get_runtime_info`** — `GET /api/v1/status/runtimeinfo`.
+- **`get_build_info`** — `GET /api/v1/status/buildinfo`.
+- **`get_tsdb_stats`** — `GET /api/v1/status/tsdb`. Optional `limit` (passed through as `?limit=`,
+  controls how many items per stats list; supported by Prometheus ≥ 2.41).
+
+## Approaches considered
+
+1. **Follow existing single-file pattern (chosen).** Add tools to `server.py` using the same
+   `@mcp.tool` + `_tool_name()` + annotations idiom, with structured logging. Low risk, matches
+   repo conventions and how every existing tool is written.
+2. **Split server.py into modules per toolset.** Better long-term structure but a refactor
+   unrelated to the goal, high review surface. Rejected (YAGNI).
+3. **Add more surface in the same pass (exemplar queries, embedded docs browsing, TSDB admin
+   endpoints).** Docs browsing requires bundling a docs snapshot; TSDB admin endpoints are
+   destructive and need an opt-in safety flag; exemplar queries are niche. Rejected — out of
+   scope for this change.
+
+## Design details
+
+- All 8 new tools are read-only GETs: annotations `readOnlyHint: true`, `destructiveHint: false`,
+  `idempotentHint: true`, `openWorldHint: true`, each with a `title` and icon, named through
+  `_tool_name()` so `TOOL_PREFIX` keeps working.
+- Repeated query params (`match[]`, `rule_name[]`, `rule_group[]`) are passed to `requests` as
+  lists, which serializes them as repeated keys.
+- Error handling: inherited from `make_prometheus_request` (raises `ValueError` on API error,
+  `requests` exceptions on transport failure) — identical to existing tools. Numeric and enum
+  inputs (`limit`, `type`) are validated client-side so callers get a clear message instead of an
+  opaque HTTP 400 whose reason `raise_for_status` discards.
+- No new dependencies, no config changes.
+
+## Testing
+
+Tests go in `tests/test_tools.py`, following the existing pattern: mock
+`make_prometheus_request`, call through `fastmcp.Client(mcp)`, assert both the forwarded
+endpoint/params and the shaped result. One happy-path test per tool plus param-forwarding
+variants (`type` filter for rules, `match`/`start`/`end` for labels/series, `limit` handling
+for series and TSDB stats) and error-case tests for every client-side validation.
+
+## Documentation
+
+Add the 8 tools to the "Available Tools" table in `README.md` under their categories
+(Alerting, Discovery, Status).

--- a/src/prometheus_mcp_server/server.py
+++ b/src/prometheus_mcp_server/server.py
@@ -659,6 +659,387 @@ async def get_targets() -> Dict[str, List[Dict[str, Any]]]:
     
     return result
 
+@mcp.tool(
+    name=_tool_name("list_alerts"),
+    description="Get all active alerts from Prometheus with their state, labels, and annotations",
+    annotations={
+        "title": "List Active Alerts",
+        "icon": "🚨",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True
+    }
+)
+async def list_alerts() -> Dict[str, Any]:
+    """Get all currently active alerts from Prometheus.
+
+    Returns:
+        Dictionary containing:
+        - alerts: List of active alerts with labels, annotations, state, and activeAt
+        - alert_count: Number of active alerts
+    """
+    logger.info("Retrieving active alerts")
+    data = make_prometheus_request("alerts", params=None)
+
+    alerts = data.get("alerts", [])
+    result = {
+        "alerts": alerts,
+        "alert_count": len(alerts)
+    }
+
+    logger.info("Active alerts retrieved", alert_count=len(alerts))
+    return result
+
+@mcp.tool(
+    name=_tool_name("list_rules"),
+    description="Get alerting and recording rules with their health, state, and evaluation info",
+    annotations={
+        "title": "List Alerting & Recording Rules",
+        "icon": "📜",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True
+    }
+)
+async def list_rules(
+    type: Optional[str] = None,
+    rule_name: Optional[List[str]] = None,
+    rule_group: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """Get alerting and recording rules currently loaded in Prometheus.
+
+    Args:
+        type: Optional rule type filter, either 'alert' or 'record'
+        rule_name: Optional list of rule names to filter by (forwarded to the server
+            on Prometheus >= 2.44 and re-applied client-side for older or
+            Prometheus-compatible backends that ignore the parameter)
+        rule_group: Optional list of rule group names to filter by (same fallback)
+
+    Returns:
+        Dictionary containing:
+        - groups: List of rule groups with their rules
+        - group_count: Number of rule groups returned
+    """
+    if type is not None and type not in ("alert", "record"):
+        raise ValueError(f"Invalid rule type: '{type}'. Must be 'alert' or 'record'.")
+
+    logger.info("Retrieving rules", type=type, rule_name=rule_name, rule_group=rule_group)
+
+    params: Dict[str, Any] = {}
+    if type:
+        params["type"] = type
+    if rule_name:
+        params["rule_name[]"] = rule_name
+    if rule_group:
+        params["rule_group[]"] = rule_group
+
+    data = make_prometheus_request("rules", params=params or None)
+
+    groups = data.get("groups", [])
+    # Prometheus < 2.44 and some compatible backends (Thanos, VictoriaMetrics) silently
+    # ignore rule_name[]/rule_group[], so re-apply the filters client-side. This is a
+    # no-op when the server already filtered.
+    if rule_group:
+        wanted_groups = set(rule_group)
+        groups = [g for g in groups if g.get("name") in wanted_groups]
+    if rule_name:
+        wanted_rules = set(rule_name)
+        groups = [
+            {**g, "rules": [r for r in g.get("rules", []) if r.get("name") in wanted_rules]}
+            for g in groups
+        ]
+        groups = [g for g in groups if g["rules"]]
+
+    result = {
+        "groups": groups,
+        "group_count": len(groups)
+    }
+
+    logger.info("Rules retrieved", group_count=len(groups))
+    return result
+
+@mcp.tool(
+    name=_tool_name("list_label_names"),
+    description="List all label names, optionally restricted to series matching selectors and a time range",
+    annotations={
+        "title": "List Label Names",
+        "icon": "🏷️",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True
+    }
+)
+async def list_label_names(
+    match: Optional[List[str]] = None,
+    start: Optional[str] = None,
+    end: Optional[str] = None,
+) -> Dict[str, Any]:
+    """List label names known to Prometheus.
+
+    Args:
+        match: Optional list of series selectors (e.g. ['up', 'node_cpu_seconds_total{job="node"}'])
+        start: Optional start time as RFC3339 or Unix timestamp
+        end: Optional end time as RFC3339 or Unix timestamp
+
+    Returns:
+        Dictionary containing:
+        - labels: List of label names
+        - count: Number of label names returned
+    """
+    logger.info("Listing label names", match=match, start=start, end=end)
+
+    params: Dict[str, Any] = {}
+    if match:
+        params["match[]"] = match
+    if start:
+        params["start"] = start
+    if end:
+        params["end"] = end
+
+    data = make_prometheus_request("labels", params=params or None)
+
+    result = {
+        "labels": data,
+        "count": len(data)
+    }
+
+    logger.info("Label names retrieved", count=len(data))
+    return result
+
+def _is_legacy_label_rune(ch: str, index: int) -> bool:
+    """Check whether a character is valid in a classic Prometheus label name."""
+    return (
+        ch == "_"
+        or "a" <= ch <= "z"
+        or "A" <= ch <= "Z"
+        or (index > 0 and "0" <= ch <= "9")
+    )
+
+
+def _escape_label_name(name: str) -> str:
+    """Escape a label name for use in a URL path using Prometheus 'values' escaping.
+
+    Names valid under the classic charset ([a-zA-Z_][a-zA-Z0-9_]*) pass through
+    unchanged. UTF-8 names (legal since Prometheus 3.x) are escaped to the U__ form
+    the API requires for path segments, since characters like '/' would otherwise
+    change the request path.
+    """
+    if all(_is_legacy_label_rune(ch, i) for i, ch in enumerate(name)):
+        return name
+
+    escaped = ["U__"]
+    for index, ch in enumerate(name):
+        if ch == "_":
+            escaped.append("__")
+        elif _is_legacy_label_rune(ch, index):
+            escaped.append(ch)
+        else:
+            escaped.append(f"_{ord(ch):x}_")
+    return "".join(escaped)
+
+
+@mcp.tool(
+    name=_tool_name("list_label_values"),
+    description="List all values for a label, optionally restricted to series matching selectors and a time range",
+    annotations={
+        "title": "List Label Values",
+        "icon": "🔤",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True
+    }
+)
+async def list_label_values(
+    label_name: str,
+    match: Optional[List[str]] = None,
+    start: Optional[str] = None,
+    end: Optional[str] = None,
+) -> Dict[str, Any]:
+    """List values for a specific label name.
+
+    Args:
+        label_name: The label name to retrieve values for (e.g. 'job', 'instance')
+        match: Optional list of series selectors to restrict the values
+        start: Optional start time as RFC3339 or Unix timestamp
+        end: Optional end time as RFC3339 or Unix timestamp
+
+    Returns:
+        Dictionary containing:
+        - values: List of values for the label
+        - count: Number of values returned
+    """
+    if not label_name:
+        raise ValueError("label_name must not be empty")
+
+    logger.info("Listing label values", label_name=label_name, match=match, start=start, end=end)
+
+    params: Dict[str, Any] = {}
+    if match:
+        params["match[]"] = match
+    if start:
+        params["start"] = start
+    if end:
+        params["end"] = end
+
+    data = make_prometheus_request(f"label/{_escape_label_name(label_name)}/values", params=params or None)
+
+    result = {
+        "values": data,
+        "count": len(data)
+    }
+
+    logger.info("Label values retrieved", label_name=label_name, count=len(data))
+    return result
+
+@mcp.tool(
+    name=_tool_name("find_series"),
+    description="Find time series matching label selectors, with optional time range and result limit",
+    annotations={
+        "title": "Find Series",
+        "icon": "🔍",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True
+    }
+)
+async def find_series(
+    match: List[str],
+    start: Optional[str] = None,
+    end: Optional[str] = None,
+    limit: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Find time series by label matchers.
+
+    Args:
+        match: List of series selectors; at least one is required
+            (e.g. ['up', 'process_start_time_seconds{job="prometheus"}'])
+        start: Optional start time as RFC3339 or Unix timestamp
+        end: Optional end time as RFC3339 or Unix timestamp
+        limit: Maximum number of series to return; must be positive (default: all)
+
+    Returns:
+        Dictionary containing:
+        - series: List of label sets identifying matching series
+        - returned_count: Number of series returned
+        - has_more: Whether more series matched than were returned
+    """
+    if not match:
+        raise ValueError("find_series requires at least one series selector in 'match'")
+    if limit is not None and limit < 1:
+        raise ValueError("limit must be a positive number")
+
+    logger.info("Finding series", match=match, start=start, end=end, limit=limit)
+
+    params: Dict[str, Any] = {"match[]": match}
+    if start:
+        params["start"] = start
+    if end:
+        params["end"] = end
+    if limit is not None:
+        # Ask for one extra series so has_more can be derived from a bounded fetch.
+        # Servers older than 2.53 ignore the param; the slice below still applies.
+        params["limit"] = limit + 1
+
+    data = make_prometheus_request("series", params=params)
+
+    series = data[:limit] if limit is not None else data
+
+    result = {
+        "series": series,
+        "returned_count": len(series),
+        "has_more": len(series) < len(data)
+    }
+
+    logger.info("Series retrieved", returned_count=len(series), has_more=result["has_more"])
+    return result
+
+@mcp.tool(
+    name=_tool_name("get_runtime_info"),
+    description="Get Prometheus runtime information such as start time, config reload status, goroutine count, and storage retention",
+    annotations={
+        "title": "Get Runtime Info",
+        "icon": "⚙️",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True
+    }
+)
+async def get_runtime_info() -> Dict[str, Any]:
+    """Get runtime information about the Prometheus server.
+
+    Returns:
+        Runtime properties including start time, working directory, config reload
+        status, goroutine count, and storage retention
+    """
+    logger.info("Retrieving runtime info")
+    data = make_prometheus_request("status/runtimeinfo")
+
+    logger.info("Runtime info retrieved")
+    return data
+
+@mcp.tool(
+    name=_tool_name("get_build_info"),
+    description="Get Prometheus build information such as version, revision, and Go version",
+    annotations={
+        "title": "Get Build Info",
+        "icon": "🏗️",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True
+    }
+)
+async def get_build_info() -> Dict[str, Any]:
+    """Get build information about the Prometheus server.
+
+    Returns:
+        Build properties including version, revision, branch, and Go version
+    """
+    logger.info("Retrieving build info")
+    data = make_prometheus_request("status/buildinfo")
+
+    logger.info("Build info retrieved", version=data.get("version"))
+    return data
+
+@mcp.tool(
+    name=_tool_name("get_tsdb_stats"),
+    description="Get TSDB cardinality statistics: head series counts and top metrics by series count",
+    annotations={
+        "title": "Get TSDB Stats",
+        "icon": "💾",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True
+    }
+)
+async def get_tsdb_stats(limit: Optional[int] = None) -> Dict[str, Any]:
+    """Get TSDB usage and cardinality statistics from Prometheus.
+
+    Args:
+        limit: Maximum number of items to return per stats list; must be positive (default: 10)
+
+    Returns:
+        TSDB statistics including head block stats and cardinality breakdowns
+        (series count by metric name, label pairs, and memory usage)
+    """
+    if limit is not None and limit < 1:
+        raise ValueError("limit must be a positive number")
+
+    logger.info("Retrieving TSDB stats", limit=limit)
+
+    params = {"limit": limit} if limit is not None else None
+    data = make_prometheus_request("status/tsdb", params=params)
+
+    logger.info("TSDB stats retrieved")
+    return data
+
 if __name__ == "__main__":
     logger.info("Starting Prometheus MCP Server", mode="direct")
     mcp.run()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -439,3 +439,362 @@ async def test_get_metric_metadata_fallback_entries(mock_make_request):
 
         assert len(json_data) == 1
         assert json_data[0]["type"] == "gauge"
+
+
+# --- Alerts & rules tools ---
+
+@pytest.mark.asyncio
+async def test_list_alerts(mock_make_request):
+    """Test the list_alerts tool."""
+    mock_make_request.return_value = {
+        "alerts": [
+            {
+                "labels": {"alertname": "HighCPU", "severity": "critical"},
+                "annotations": {"summary": "CPU usage is high"},
+                "state": "firing",
+                "activeAt": "2023-01-01T00:00:00Z",
+                "value": "9.5e+01"
+            }
+        ]
+    }
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("list_alerts", {})
+
+        mock_make_request.assert_called_once_with("alerts", params=None)
+        assert result.data["alert_count"] == 1
+        assert result.data["alerts"][0]["state"] == "firing"
+        assert result.data["alerts"][0]["labels"]["alertname"] == "HighCPU"
+
+@pytest.mark.asyncio
+async def test_list_rules(mock_make_request):
+    """Test the list_rules tool without filters."""
+    mock_make_request.return_value = {
+        "groups": [
+            {
+                "name": "example",
+                "file": "/rules.yml",
+                "rules": [
+                    {"name": "HighCPU", "type": "alerting", "state": "firing", "query": "cpu > 90"}
+                ]
+            }
+        ]
+    }
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("list_rules", {})
+
+        mock_make_request.assert_called_once_with("rules", params=None)
+        assert result.data["group_count"] == 1
+        assert result.data["groups"][0]["name"] == "example"
+
+@pytest.mark.asyncio
+async def test_list_rules_with_type_filter(mock_make_request):
+    """Test the list_rules tool with a rule type filter."""
+    mock_make_request.return_value = {"groups": []}
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("list_rules", {"type": "alert"})
+
+        mock_make_request.assert_called_once_with("rules", params={"type": "alert"})
+        assert result.data["group_count"] == 0
+
+@pytest.mark.asyncio
+async def test_list_rules_with_name_and_group_filters(mock_make_request):
+    """Test the list_rules tool with rule_name and rule_group filters."""
+    mock_make_request.return_value = {"groups": []}
+
+    async with Client(mcp) as client:
+        await client.call_tool("list_rules", {
+            "rule_name": ["HighCPU"],
+            "rule_group": ["example"]
+        })
+
+        mock_make_request.assert_called_once_with("rules", params={
+            "rule_name[]": ["HighCPU"],
+            "rule_group[]": ["example"]
+        })
+
+@pytest.mark.asyncio
+async def test_list_rules_filters_client_side_when_server_ignores_params(mock_make_request):
+    """Test list_rules post-filters results for servers that ignore rule_name[]/rule_group[].
+
+    Prometheus < 2.44 and some compatible backends (Thanos, VictoriaMetrics) silently
+    ignore the filter params, so the tool must not present unfiltered data as filtered.
+    """
+    mock_make_request.return_value = {
+        "groups": [
+            {
+                "name": "g1",
+                "file": "/rules.yml",
+                "rules": [
+                    {"name": "HighCPU", "type": "alerting"},
+                    {"name": "Other", "type": "alerting"}
+                ]
+            },
+            {
+                "name": "g2",
+                "file": "/rules.yml",
+                "rules": [{"name": "Other2", "type": "alerting"}]
+            }
+        ]
+    }
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("list_rules", {"rule_name": ["HighCPU"]})
+
+        assert result.data["group_count"] == 1
+        assert result.data["groups"][0]["name"] == "g1"
+        assert [r["name"] for r in result.data["groups"][0]["rules"]] == ["HighCPU"]
+
+@pytest.mark.asyncio
+async def test_list_rules_filters_groups_client_side(mock_make_request):
+    """Test list_rules post-filters by group name when the server ignores rule_group[]."""
+    mock_make_request.return_value = {
+        "groups": [
+            {"name": "g1", "file": "/rules.yml", "rules": [{"name": "A", "type": "alerting"}]},
+            {"name": "g2", "file": "/rules.yml", "rules": [{"name": "B", "type": "alerting"}]}
+        ]
+    }
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("list_rules", {"rule_group": ["g2"]})
+
+        assert result.data["group_count"] == 1
+        assert result.data["groups"][0]["name"] == "g2"
+
+@pytest.mark.asyncio
+async def test_list_rules_rejects_invalid_type(mock_make_request):
+    """Test the list_rules tool rejects an invalid rule type."""
+    async with Client(mcp) as client:
+        with pytest.raises(Exception, match="Invalid rule type"):
+            await client.call_tool("list_rules", {"type": "bogus"})
+
+        mock_make_request.assert_not_called()
+
+
+# --- Label & series exploration tools ---
+
+@pytest.mark.asyncio
+async def test_list_label_names(mock_make_request):
+    """Test the list_label_names tool."""
+    mock_make_request.return_value = ["__name__", "instance", "job"]
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("list_label_names", {})
+
+        mock_make_request.assert_called_once_with("labels", params=None)
+        assert result.data["labels"] == ["__name__", "instance", "job"]
+        assert result.data["count"] == 3
+
+@pytest.mark.asyncio
+async def test_list_label_names_with_match_and_time_range(mock_make_request):
+    """Test the list_label_names tool forwards match selectors and time range."""
+    mock_make_request.return_value = ["job"]
+
+    async with Client(mcp) as client:
+        await client.call_tool("list_label_names", {
+            "match": ["up", "process_start_time_seconds{job=\"prometheus\"}"],
+            "start": "2023-01-01T00:00:00Z",
+            "end": "2023-01-01T01:00:00Z"
+        })
+
+        mock_make_request.assert_called_once_with("labels", params={
+            "match[]": ["up", "process_start_time_seconds{job=\"prometheus\"}"],
+            "start": "2023-01-01T00:00:00Z",
+            "end": "2023-01-01T01:00:00Z"
+        })
+
+@pytest.mark.asyncio
+async def test_list_label_values(mock_make_request):
+    """Test the list_label_values tool."""
+    mock_make_request.return_value = ["prometheus", "node-exporter"]
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("list_label_values", {"label_name": "job"})
+
+        mock_make_request.assert_called_once_with("label/job/values", params=None)
+        assert result.data["values"] == ["prometheus", "node-exporter"]
+        assert result.data["count"] == 2
+
+@pytest.mark.asyncio
+async def test_list_label_values_with_match_and_time_range(mock_make_request):
+    """Test the list_label_values tool forwards match selectors and time range."""
+    mock_make_request.return_value = ["prometheus"]
+
+    async with Client(mcp) as client:
+        await client.call_tool("list_label_values", {
+            "label_name": "job",
+            "match": ["up"],
+            "start": "2023-01-01T00:00:00Z",
+            "end": "2023-01-01T01:00:00Z"
+        })
+
+        mock_make_request.assert_called_once_with("label/job/values", params={
+            "match[]": ["up"],
+            "start": "2023-01-01T00:00:00Z",
+            "end": "2023-01-01T01:00:00Z"
+        })
+
+@pytest.mark.asyncio
+async def test_list_label_values_rejects_empty_label_name(mock_make_request):
+    """Test the list_label_values tool rejects an empty label name."""
+    async with Client(mcp) as client:
+        with pytest.raises(Exception, match="label_name must not be empty"):
+            await client.call_tool("list_label_values", {"label_name": ""})
+
+        mock_make_request.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_list_label_values_escapes_utf8_label_name(mock_make_request):
+    """Test that UTF-8 label names get Prometheus U__ values-escaping in the URL path."""
+    mock_make_request.return_value = ["frontend"]
+
+    async with Client(mcp) as client:
+        await client.call_tool("list_label_values", {"label_name": "app.kubernetes.io/name"})
+
+        mock_make_request.assert_called_once_with(
+            "label/U__app_2e_kubernetes_2e_io_2f_name/values", params=None
+        )
+
+@pytest.mark.asyncio
+async def test_find_series(mock_make_request):
+    """Test the find_series tool."""
+    mock_make_request.return_value = [
+        {"__name__": "up", "job": "prometheus", "instance": "localhost:9090"},
+        {"__name__": "up", "job": "node", "instance": "localhost:9100"}
+    ]
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("find_series", {"match": ["up"]})
+
+        mock_make_request.assert_called_once_with("series", params={"match[]": ["up"]})
+        assert result.data["returned_count"] == 2
+        assert result.data["has_more"] == False
+        assert result.data["series"][0]["job"] == "prometheus"
+
+@pytest.mark.asyncio
+async def test_find_series_with_limit_and_time_range(mock_make_request):
+    """Test the find_series tool forwards a server-side limit of limit+1 and time range.
+
+    The extra series (limit+1) is how has_more is detected with a bounded fetch;
+    servers older than 2.53 ignore the param and the client-side slice still applies.
+    """
+    mock_make_request.return_value = [
+        {"__name__": "up", "job": "a"},
+        {"__name__": "up", "job": "b"},
+        {"__name__": "up", "job": "c"}
+    ]
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("find_series", {
+            "match": ["up"],
+            "start": "2023-01-01T00:00:00Z",
+            "end": "2023-01-01T01:00:00Z",
+            "limit": 2
+        })
+
+        mock_make_request.assert_called_once_with("series", params={
+            "match[]": ["up"],
+            "start": "2023-01-01T00:00:00Z",
+            "end": "2023-01-01T01:00:00Z",
+            "limit": 3
+        })
+        assert result.data["returned_count"] == 2
+        assert result.data["has_more"] == True
+        assert len(result.data["series"]) == 2
+
+@pytest.mark.asyncio
+async def test_find_series_requires_match(mock_make_request):
+    """Test the find_series tool rejects an empty match list."""
+    async with Client(mcp) as client:
+        with pytest.raises(Exception, match="at least one series selector"):
+            await client.call_tool("find_series", {"match": []})
+
+        mock_make_request.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_find_series_rejects_non_positive_limit(mock_make_request):
+    """Test the find_series tool rejects zero and negative limits."""
+    async with Client(mcp) as client:
+        with pytest.raises(Exception, match="positive"):
+            await client.call_tool("find_series", {"match": ["up"], "limit": 0})
+        with pytest.raises(Exception, match="positive"):
+            await client.call_tool("find_series", {"match": ["up"], "limit": -1})
+
+        mock_make_request.assert_not_called()
+
+
+# --- Runtime & build diagnostics tools ---
+
+@pytest.mark.asyncio
+async def test_get_runtime_info(mock_make_request):
+    """Test the get_runtime_info tool."""
+    mock_make_request.return_value = {
+        "startTime": "2023-01-01T00:00:00Z",
+        "CWD": "/prometheus",
+        "reloadConfigSuccess": True,
+        "goroutineCount": 42,
+        "storageRetention": "15d"
+    }
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("get_runtime_info", {})
+
+        mock_make_request.assert_called_once_with("status/runtimeinfo")
+        assert result.data["goroutineCount"] == 42
+        assert result.data["storageRetention"] == "15d"
+
+@pytest.mark.asyncio
+async def test_get_build_info(mock_make_request):
+    """Test the get_build_info tool."""
+    mock_make_request.return_value = {
+        "version": "3.0.0",
+        "revision": "abc123",
+        "branch": "HEAD",
+        "goVersion": "go1.23.0"
+    }
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("get_build_info", {})
+
+        mock_make_request.assert_called_once_with("status/buildinfo")
+        assert result.data["version"] == "3.0.0"
+        assert result.data["goVersion"] == "go1.23.0"
+
+@pytest.mark.asyncio
+async def test_get_tsdb_stats(mock_make_request):
+    """Test the get_tsdb_stats tool."""
+    mock_make_request.return_value = {
+        "headStats": {"numSeries": 508, "chunkCount": 937},
+        "seriesCountByMetricName": [{"name": "net_conntrack_dialer_conn_failed_total", "value": 20}]
+    }
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("get_tsdb_stats", {})
+
+        mock_make_request.assert_called_once_with("status/tsdb", params=None)
+        assert result.data["headStats"]["numSeries"] == 508
+
+@pytest.mark.asyncio
+async def test_get_tsdb_stats_with_limit(mock_make_request):
+    """Test the get_tsdb_stats tool forwards the limit parameter."""
+    mock_make_request.return_value = {"headStats": {"numSeries": 508}}
+
+    async with Client(mcp) as client:
+        await client.call_tool("get_tsdb_stats", {"limit": 5})
+
+        mock_make_request.assert_called_once_with("status/tsdb", params={"limit": 5})
+
+@pytest.mark.asyncio
+async def test_get_tsdb_stats_rejects_non_positive_limit(mock_make_request):
+    """Test the get_tsdb_stats tool rejects limit < 1 before making a request.
+
+    Prometheus rejects limit < 1 with an HTTP 400 whose reason gets swallowed by
+    raise_for_status, so the tool validates client-side for a clear error.
+    """
+    async with Client(mcp) as client:
+        with pytest.raises(Exception, match="positive"):
+            await client.call_tool("get_tsdb_stats", {"limit": 0})
+
+        mock_make_request.assert_not_called()


### PR DESCRIPTION
## Summary

Adds eight read-only tools that close the biggest gaps for AI-assistant-driven investigation: seeing what is firing, discovering labels to build valid PromQL, and inspecting the server itself.

**Alerting**
- `list_alerts` — active alerts with state, labels, and annotations (`/api/v1/alerts`)
- `list_rules` — alerting/recording rules with optional `type`, `rule_name`, and `rule_group` filters (`/api/v1/rules`). Filters are forwarded server-side and re-applied client-side, since Prometheus < 2.44 and some compatible backends (Thanos, VictoriaMetrics) silently ignore the filter params and would otherwise return unfiltered data presented as filtered.

**Discovery**
- `list_label_names` / `list_label_values` — generic label exploration with `match[]` selectors and time range (`/api/v1/labels`, `/api/v1/label/{name}/values`). UTF-8 label names (e.g. `app.kubernetes.io/name`, legal since Prometheus 3.x) get Prometheus `U__` values-escaping so `/` cannot change the request path.
- `find_series` — series lookup by label matchers (`/api/v1/series`). `limit` is forwarded as `limit+1` server-side (honored since Prometheus 2.53, harmlessly ignored by older versions) so broad selectors on high-cardinality servers do not transfer the full series set; the extra series only signals `has_more`.

**Status**
- `get_runtime_info`, `get_build_info`, `get_tsdb_stats` — runtime, build, and TSDB cardinality diagnostics (`/api/v1/status/*`), with `limit` passthrough for the stats lists.

All tools are read-only (`readOnlyHint`), named through `_tool_name()` so `TOOL_PREFIX` keeps working, go through the existing `make_prometheus_request` path (auth, TLS, org ID, custom headers, timeouts), and validate enum/numeric inputs client-side so callers get a clear error message instead of an opaque HTTP 400 whose reason `raise_for_status` discards.

The design spec is included under `docs/superpowers/specs/` and the README tools table is updated.

## Testing

- 22 new tests in `tests/test_tools.py` covering happy paths, param forwarding, and every client-side validation error case; full suite: 176 passed, coverage 99.3% (gate: 80%)
- Exercised end-to-end against a live Prometheus 3.13 container: all eight tools returned correct data, including the bounded `find_series` fetch (666-series result, `limit=3`, `has_more=true`), escaped UTF-8 label paths, and client-side rule filtering