### PR TITLE
feat: add MCP 2026-07-28 protocol support

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -32,3 +32,12 @@ PROMETHEUS_TOKEN=your_token
 # PROMETHEUS_MCP_BIND_HOST=localhost # if undefined, 127.0.0.1 is set by default.
 # PROMETHEUS_MCP_BIND_PORT=8080 # if undefined, 8080 is set by default.
 # PROMETHEUS_MCP_STATELESS_HTTP=false # Enable stateless HTTP mode for multi-replica support.
+
+# Optional: MCP 2026-07-28 protocol support
+# The server speaks 2026-07-28, 2025-11-25 and 2025-06-18. All settings below are
+# additive and older clients are unaffected.
+# PROMETHEUS_MCP_SPEC_2026=true # Master switch for the 2026-07-28 layer. Default: true.
+# PROMETHEUS_MCP_CACHE_TTL_MS=300000 # ttlMs advertised on cacheable results. Default: 300000 (5 min).
+# PROMETHEUS_MCP_CACHE_SCOPE=public # cacheScope advertised on cacheable results: public or private.
+# PROMETHEUS_MCP_STRICT_HEADERS=false # Reject an HTTP request whose Mcp-* headers contradict its JSON-RPC body (HTTP 400 + code -32020). Default: false.
+# PROMETHEUS_MCP_ALLOW_ORG_ID_OVERRIDE=false # Let a per-call org_id tool argument override ORG_ID. Leave off: X-Scope-OrgID is the only tenancy boundary in Mimir/Cortex/Thanos. Default: false.

--- a/README.md
+++ b/README.md
@@ -170,13 +170,18 @@ See the [chart values](charts/prometheus-mcp-server/values.yaml) for all availab
 | `PROMETHEUS_CLIENT_CERT` | Path to client certificate file for mutual TLS authentication | No |
 | `PROMETHEUS_CLIENT_KEY` | Path to client private key file for mutual TLS authentication | No |
 | `REQUESTS_CA_BUNDLE` | Path to CA bundle file for verifying the server's TLS certificate (standard `requests` library env var) | No |
-| `ORG_ID` | Organization ID for multi-tenant setups | No |
+| `ORG_ID` | Organization ID for multi-tenant setups, sent as `X-Scope-OrgID`. Always wins over a per-call `org_id` tool argument unless `PROMETHEUS_MCP_ALLOW_ORG_ID_OVERRIDE` is set | No |
 | `PROMETHEUS_MCP_SERVER_TRANSPORT` | Transport mode (stdio, http, sse) | No (default: stdio) |
 | `PROMETHEUS_MCP_BIND_HOST` | Host for HTTP transport | No (default: 127.0.0.1) |
 | `PROMETHEUS_MCP_BIND_PORT` | Port for HTTP transport | No (default: 8080) |
 | `PROMETHEUS_MCP_STATELESS_HTTP` | Enable stateless HTTP mode for multi-replica support | No (default: False) |
 | `PROMETHEUS_CUSTOM_HEADERS` | Custom headers as JSON string | No |
 | `TOOL_PREFIX` | Prefix for all tool names (e.g., `staging` results in `staging_execute_query`). Useful for running multiple instances targeting different environments in Cursor | No |
+| `PROMETHEUS_MCP_SPEC_2026` | Master switch for the MCP 2026-07-28 protocol layer | No (default: True) |
+| `PROMETHEUS_MCP_CACHE_TTL_MS` | Cache lifetime advertised as `ttlMs` on cacheable results | No (default: 300000) |
+| `PROMETHEUS_MCP_CACHE_SCOPE` | Cache scope advertised on cacheable results (`public` or `private`) | No (default: public) |
+| `PROMETHEUS_MCP_STRICT_HEADERS` | Reject an HTTP request whose `Mcp-*` headers contradict its JSON-RPC body (HTTP 400, code `-32020`) | No (default: False) |
+| `PROMETHEUS_MCP_ALLOW_ORG_ID_OVERRIDE` | Allow a per-call `org_id` tool argument to override a configured `ORG_ID` | No (default: False) |
 
 ## Available Tools
 
@@ -188,8 +193,49 @@ See the [chart values](charts/prometheus-mcp-server/values.yaml) for all availab
 | `list_metrics` | Discovery | List all available metrics in Prometheus with pagination and filtering support |
 | `get_metric_metadata` | Discovery | Get metadata for one metric or bulk metadata with optional filtering |
 | `get_targets` | Discovery | Get information about all scrape targets |
+| `server_discover` | System | Return the server's MCP 2026-07-28 discovery document |
 
 The list of tools is configurable, so you can choose which tools you want to make available to the MCP client. This is useful if you don't use certain functionality or if you don't want to take up too much of the context window.
+
+## MCP 2026-07-28 Support
+
+The server accepts `2026-07-28`, `2025-11-25` and `2025-06-18`. Support for the newest
+revision is a compatibility layer on top of the MCP SDK (which implements `2025-11-25`),
+so it is entirely additive — clients on older revisions see the server unchanged.
+
+- **`server/discover`** is reachable three ways: as a JSON-RPC method on every transport,
+  as `GET /server/discover` (the only pre-handshake route, alongside `/health`), and as the
+  `server_discover` tool.
+- **Result envelope** — every result carries `resultType` and
+  `_meta["io.modelcontextprotocol/serverInfo"]`. Cacheable results (`server/discover`,
+  `tools/list`, `prompts/list`, `resources/list`, `resources/templates/list`,
+  `resources/read`) also carry `ttlMs` and `cacheScope`; `tools/call` does not.
+- **Deterministic ordering** — `tools/list` returns tools sorted by name, so clients get
+  stable prompt-cache keys.
+- **Per-request negotiation** — `params._meta` may carry
+  `io.modelcontextprotocol/protocolVersion`, `clientCapabilities`, `clientInfo` and
+  `logLevel`. An unrecognised protocol version is rejected with JSON-RPC code `-32022`;
+  a request that declares none is treated as legacy and served normally.
+- **Trace context** — `traceparent`, `tracestate` and `baggage` in `params._meta` are
+  validated against W3C Trace Context and forwarded as headers on the outbound Prometheus
+  request. Malformed values are dropped, and `PROMETHEUS_CUSTOM_HEADERS` always takes
+  precedence over per-request values.
+- **`x-mcp-header`** — `execute_query` annotates its optional `org_id` parameter with
+  `x-mcp-header: Org-Id`, so the tenant may also be sent as the `Mcp-Param-Org-Id` header.
+  The value is sent to Prometheus as `X-Scope-OrgID`. **A configured `ORG_ID` always
+  wins**: `X-Scope-OrgID` is the only tenancy boundary in Mimir/Cortex/Thanos and the
+  caller is typically an LLM acting on untrusted content, so a client-supplied tenant is
+  only honoured when no `ORG_ID` is configured, or when the operator explicitly sets
+  `PROMETHEUS_MCP_ALLOW_ORG_ID_OVERRIDE=true`. Values that are not safe plain ASCII (CR,
+  LF, non-ASCII) are refused before they reach an outbound header.
+- **Strict header validation** — set `PROMETHEUS_MCP_STRICT_HEADERS=true` to reject an
+  HTTP request whose `Mcp-*` headers contradict its JSON-RPC body, with HTTP 400 and code
+  `-32020`. The `Mcp-*` headers are optional hints, so omitting one is never an error and
+  clients that send none are unaffected; only a header that actually disagrees with the
+  body is rejected. `MCP-Protocol-Version` is a transport header rather than a body
+  mirror and is only compared when the body declares a pre-2026 revision.
+
+Set `PROMETHEUS_MCP_SPEC_2026=false` to turn the whole layer off.
 
 ## Features
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,14 @@ dev = [
 prometheus-mcp-server = "prometheus_mcp_server.main:run_server"
 
 [tool.setuptools]
-packages = ["prometheus_mcp_server"]
 package-dir = {"" = "src"}
+
+# Discover subpackages automatically. An explicit `packages = [...]` list does not
+# include subpackages, which silently dropped prometheus_mcp_server.spec2026 from
+# built wheels even though server.py imports it at module load.
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["prometheus_mcp_server*"]
 
 [build-system]
 requires = ["setuptools>=61.0"]

--- a/server.json
+++ b/server.json
@@ -114,6 +114,41 @@
           "isRequired": false,
           "format": "string",
           "isSecret": false
+        },
+        {
+          "name": "PROMETHEUS_MCP_SPEC_2026",
+          "description": "Master switch for the MCP 2026-07-28 compatibility layer (default: true)",
+          "isRequired": false,
+          "format": "boolean",
+          "isSecret": false
+        },
+        {
+          "name": "PROMETHEUS_MCP_CACHE_TTL_MS",
+          "description": "Cache lifetime in milliseconds advertised as ttlMs on cacheable results (default: 300000)",
+          "isRequired": false,
+          "format": "number",
+          "isSecret": false
+        },
+        {
+          "name": "PROMETHEUS_MCP_CACHE_SCOPE",
+          "description": "Cache scope advertised on cacheable results: public or private (default: public)",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "PROMETHEUS_MCP_STRICT_HEADERS",
+          "description": "Reject an HTTP request whose Mcp-* headers contradict its JSON-RPC body, with HTTP 400 and code -32020 (default: false)",
+          "isRequired": false,
+          "format": "boolean",
+          "isSecret": false
+        },
+        {
+          "name": "PROMETHEUS_MCP_ALLOW_ORG_ID_OVERRIDE",
+          "description": "Allow a per-call org_id tool argument to override a configured ORG_ID. Leave off unless the deployment intends cross-tenant reads (default: false)",
+          "isRequired": false,
+          "format": "boolean",
+          "isSecret": false
         }
       ]
     }

--- a/src/prometheus_mcp_server/main.py
+++ b/src/prometheus_mcp_server/main.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python
 import sys
 import dotenv
-from prometheus_mcp_server.server import mcp, config, TransportType
+from prometheus_mcp_server.server import (
+    mcp,
+    config,
+    strict_header_asgi_middleware,
+    TransportType,
+)
 from prometheus_mcp_server.logging_config import setup_logging
 
 # Initialize structured logging
@@ -74,10 +79,15 @@ def run_server():
 
     http_transports = [TransportType.HTTP.value, TransportType.SSE.value]
     if transport in http_transports:
+        # Strict Mcp-* header validation is an ASGI concern: only there is the
+        # raw JSON-RPC body still available and the HTTP status still ours to
+        # choose. Returns None (and adds nothing) unless the operator opted in.
+        asgi_middleware = strict_header_asgi_middleware()
         mcp.run(
             transport=transport,
             host=mcp_config.mcp_bind_host,
             port=mcp_config.mcp_bind_port,
+            **({"middleware": [asgi_middleware]} if asgi_middleware else {}),
             **({"stateless_http": True} if mcp_config.stateless_http else {})
         )
         logger.info("Starting Prometheus MCP Server",

--- a/src/prometheus_mcp_server/server.py
+++ b/src/prometheus_mcp_server/server.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
+import inspect
 import os
 import json
-from typing import Any, Dict, List, Optional, Union
+from typing import Annotated, Any, Dict, List, Optional, Union
 from dataclasses import dataclass
 import time
 from datetime import datetime, timedelta
@@ -11,7 +12,10 @@ from enum import Enum
 import dotenv
 import requests
 from fastmcp import FastMCP, Context
+from pydantic import Field
 from prometheus_mcp_server.logging_config import get_logger
+from prometheus_mcp_server.spec2026.headers import is_safe_plain_ascii
+from prometheus_mcp_server.spec2026.otel import get_trace_headers
 
 dotenv.load_dotenv()
 
@@ -155,6 +159,50 @@ class PrometheusConfig:
     custom_headers: Optional[Dict[str, str]] = None
     # Request timeout in seconds to prevent hanging requests (DDoS protection)
     request_timeout: int = 30
+    # MCP 2026-07-28 compatibility layer (see prometheus_mcp_server.spec2026)
+    spec_2026_enabled: bool = True
+    # Advertised cache lifetime in milliseconds for cacheable result envelopes.
+    # Deliberately separate from _CACHE_TTL, which governs the in-process
+    # metrics cache and is measured in seconds.
+    cache_ttl_ms: int = 300000
+    # Advertised cache scope for cacheable result envelopes: "public" or "private"
+    cache_scope: str = "public"
+    # Opt-in strict validation of the Mcp-* request headers against the body
+    strict_headers: bool = False
+    # Opt-in: let a per-call org_id override an operator-configured ORG_ID.
+    # Off by default because X-Scope-OrgID is the only tenancy boundary in
+    # Mimir/Cortex/Thanos, so honouring a client-supplied tenant when the
+    # operator has pinned one is a cross-tenant data-access hole.
+    allow_org_id_override: bool = False
+
+
+def _env_int(name: str, default: int) -> int:
+    """Read an integer environment variable without ever failing at import.
+
+    A malformed value must not take the process down before any logging is
+    configured, so it is reported and the documented default is used instead.
+
+    Args:
+        name: Environment variable to read.
+        default: Value to fall back to when the variable is absent or unusable.
+
+    Returns:
+        The parsed integer, or ``default``.
+    """
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid integer environment variable, using default",
+            variable=name,
+            value=raw,
+            default=default,
+        )
+        return default
+
 
 config = PrometheusConfig(
     url=os.environ.get("PROMETHEUS_URL", ""),
@@ -174,6 +222,11 @@ config = PrometheusConfig(
     client_key=os.environ.get("PROMETHEUS_CLIENT_KEY", "") or None,
     custom_headers=json.loads(os.environ.get("PROMETHEUS_CUSTOM_HEADERS")) if os.environ.get("PROMETHEUS_CUSTOM_HEADERS") else None,
     request_timeout=int(os.environ.get("PROMETHEUS_REQUEST_TIMEOUT", "30")),
+    spec_2026_enabled=os.environ.get("PROMETHEUS_MCP_SPEC_2026", "True").lower() in ("true", "1", "yes"),
+    cache_ttl_ms=_env_int("PROMETHEUS_MCP_CACHE_TTL_MS", 300000),
+    cache_scope=os.environ.get("PROMETHEUS_MCP_CACHE_SCOPE", "public").lower(),
+    strict_headers=os.environ.get("PROMETHEUS_MCP_STRICT_HEADERS", "False").lower() in ("true", "1", "yes"),
+    allow_org_id_override=os.environ.get("PROMETHEUS_MCP_ALLOW_ORG_ID_OVERRIDE", "False").lower() in ("true", "1", "yes"),
 )
 
 def get_prometheus_auth():
@@ -184,8 +237,61 @@ def get_prometheus_auth():
         return requests.auth.HTTPBasicAuth(config.username, config.password)
     return None
 
-def make_prometheus_request(endpoint, params=None):
-    """Make a request to the Prometheus API with proper authentication and headers."""
+def resolve_org_id(org_id: Optional[str]) -> Optional[str]:
+    """Decide which tenant id, if any, belongs on the outbound request.
+
+    ``X-Scope-OrgID`` is the *only* tenancy boundary in Mimir/Cortex/Thanos, and
+    the caller here is typically an LLM acting on untrusted content, so a
+    client-supplied tenant must never silently displace one the operator pinned
+    via ``ORG_ID``. The precedence is therefore:
+
+    1. An operator-configured ``ORG_ID`` wins, unless the operator additionally
+       set ``PROMETHEUS_MCP_ALLOW_ORG_ID_OVERRIDE``.
+    2. With no ``ORG_ID`` configured, a per-call value is used as-is.
+    3. Either way the value must be safe plain ASCII, so a CR/LF or a non-ASCII
+       smuggling attempt never reaches an outbound header.
+
+    Args:
+        org_id: Tenant id supplied with this call, or None.
+
+    Returns:
+        The tenant id to send, or None when no ``X-Scope-OrgID`` should be set.
+    """
+    configured = config.org_id or None
+    if not org_id:
+        return configured
+
+    if not isinstance(org_id, str) or not is_safe_plain_ascii(org_id):
+        logger.warning(
+            "Rejecting unsafe per-call org_id; falling back to the configured tenant",
+            org_id_type=type(org_id).__name__,
+        )
+        return configured
+
+    if configured and not config.allow_org_id_override:
+        logger.warning(
+            "Ignoring per-call org_id because ORG_ID is configured",
+            switch="PROMETHEUS_MCP_ALLOW_ORG_ID_OVERRIDE",
+        )
+        return configured
+
+    logger.info("Using per-call tenant for this Prometheus request", org_id=org_id)
+    return org_id
+
+
+def make_prometheus_request(endpoint, params=None, org_id=None):
+    """Make a request to the Prometheus API with proper authentication and headers.
+
+    Args:
+        endpoint: Prometheus API endpoint below /api/v1/ (e.g. 'query', 'targets')
+        params: Optional query string parameters
+        org_id: Optional per-call tenant id. Only honoured when the operator
+            configured no ORG_ID, or explicitly opted into overrides via
+            PROMETHEUS_MCP_ALLOW_ORG_ID_OVERRIDE. See :func:`resolve_org_id`.
+
+    Returns:
+        The 'data' member of the Prometheus API response
+    """
     if not config.url:
         logger.error("Prometheus configuration missing", error="PROMETHEUS_URL not set")
         raise ValueError("Prometheus configuration is missing. Please set PROMETHEUS_URL environment variable.")
@@ -201,9 +307,18 @@ def make_prometheus_request(endpoint, params=None):
         headers.update(auth)
         auth = None  # Clear auth for requests.get if it's already in headers
     
-    # Add OrgID header if specified
-    if config.org_id:
-        headers["X-Scope-OrgID"] = config.org_id
+    # Add OrgID header if specified. An operator-configured ORG_ID always wins
+    # over a per-call value unless the operator opted into overrides.
+    effective_org_id = resolve_org_id(org_id)
+    if effective_org_id:
+        headers["X-Scope-OrgID"] = effective_org_id
+
+    # W3C trace context taken from the incoming request's _meta (2026-07-28
+    # minor change #2). Merged *before* custom_headers so operator-configured
+    # headers always win: a per-request value must never silently override
+    # static deployment configuration. Empty for clients that send no trace
+    # context, so this is a no-op on the 2025-11-25 path.
+    headers.update(get_trace_headers())
 
     if config.custom_headers:
         headers.update(config.custom_headers)
@@ -275,6 +390,52 @@ def get_cached_metrics() -> List[str]:
 # Note: Argument completions will be added when FastMCP supports the completion
 # capability. The get_cached_metrics() function above is ready for that integration.
 
+def _org_id_json_schema(schema: Dict[str, Any]) -> None:
+    """Attach the 2026-07-28 x-mcp-header annotation to the org_id property.
+
+    Pydantic renders Optional[str] as an anyOf union, but the specification only
+    permits the annotation on a primitive integer/string/boolean property, so
+    the union is collapsed to a plain string first. Pydantic's ``default: null``
+    is dropped along with it: a null default does not validate against the
+    declared ``string`` type, and a client that checks its own arguments against
+    the published inputSchema (or that materialises declared defaults into the
+    argument object) would reject a call the server happily accepts.
+
+    Args:
+        schema: The generated JSON Schema fragment for the property, edited in place.
+
+    Returns:
+        None
+    """
+    schema.pop("anyOf", None)
+    schema.pop("default", None)
+    schema["type"] = "string"
+    schema["x-mcp-header"] = "Org-Id"
+
+
+# Type of the optional multi-tenant override. An MCP 2026-07-28 client may mirror
+# the value in the Mcp-Param-Org-Id HTTP header; older clients simply pass it as a
+# normal argument. Only honoured when the operator configured no ORG_ID, or opted
+# into overrides -- see resolve_org_id.
+#
+# The parameter defaults to "" rather than None: FastMCP publishes the signature
+# default in the inputSchema *after* json_schema_extra has run, so a None default
+# would advertise `default: null` on a property this annotation forces to
+# `type: "string"`. A client that validates its arguments against the advertised
+# schema (or that materialises declared defaults) would then reject the very
+# value the schema told it to send. "" validates, and reads as "no tenant".
+OrgIdParam = Annotated[
+    Optional[str],
+    Field(
+        description=(
+            "Tenant id sent as X-Scope-OrgID. Ignored when the server has ORG_ID "
+            "configured, unless the operator enabled PROMETHEUS_MCP_ALLOW_ORG_ID_OVERRIDE"
+        ),
+        json_schema_extra=_org_id_json_schema,
+    ),
+]
+
+
 @mcp.tool(
     name=_tool_name("execute_query"),
     description="Execute a PromQL instant query against Prometheus",
@@ -287,12 +448,17 @@ def get_cached_metrics() -> List[str]:
         "openWorldHint": True
     }
 )
-async def execute_query(query: str, time: Optional[str] = None) -> Dict[str, Any]:
+async def execute_query(query: str, time: Optional[str] = None, org_id: OrgIdParam = "") -> Dict[str, Any]:
     """Execute an instant query against Prometheus.
 
     Args:
         query: PromQL query string
         time: Optional RFC3339 or Unix timestamp (default: current time)
+        org_id: Optional tenant id sent as X-Scope-OrgID for this call only.
+            Ignored when the operator configured ORG_ID and did not enable
+            PROMETHEUS_MCP_ALLOW_ORG_ID_OVERRIDE. Annotated with
+            ``x-mcp-header: Org-Id`` so a 2026-07-28 client may also send it as
+            the ``Mcp-Param-Org-Id`` HTTP header.
 
     Returns:
         Query result with type (vector, matrix, scalar, string) and values
@@ -300,9 +466,13 @@ async def execute_query(query: str, time: Optional[str] = None) -> Dict[str, Any
     params = {"query": query}
     if time:
         params["time"] = time
-    
-    logger.info("Executing instant query", query=query, time=time)
-    data = make_prometheus_request("query", params=params)
+
+    logger.info("Executing instant query", query=query, time=time, org_id=org_id)
+
+    # Forward the tenant override only when one was supplied, so the single-tenant
+    # call is byte-for-byte what it has always been.
+    tenant_kwargs = {"org_id": org_id} if org_id else {}
+    data = make_prometheus_request("query", params=params, **tenant_kwargs)
 
     result = {
         "resultType": data["resultType"],
@@ -658,6 +828,325 @@ async def get_targets() -> Dict[str, List[Dict[str, Any]]]:
                 dropped_targets=len(data["droppedTargets"]))
     
     return result
+
+# ---------------------------------------------------------------------------
+# MCP 2026-07-28 compatibility layer
+#
+# The installed mcp SDK implements 2025-11-25, so every 2026-07-28 behaviour is
+# added here on top of it (see prometheus_mcp_server.spec2026). Everything below
+# is additive and switched off wholesale by PROMETHEUS_MCP_SPEC_2026=false.
+# ---------------------------------------------------------------------------
+
+#: Version advertised in the 2026-07-28 result envelope and discovery document.
+#: Kept in step with pyproject.toml and server.json by sync-version.yml.
+SERVER_VERSION = "1.6.1"
+
+from prometheus_mcp_server.spec2026.asgi import (
+    strict_header_middleware,
+    tool_annotation_lookup,
+)
+from prometheus_mcp_server.spec2026.discovery import install_discovery
+from prometheus_mcp_server.spec2026.envelope import (
+    _WRAPPER_MARKER as _ENVELOPE_WRAPPER_MARKER,
+    _get_request_handlers,
+    install_envelope,
+    install_initialize_envelope,
+)
+from prometheus_mcp_server.spec2026.negotiation import (
+    NegotiationError,
+    extract_request_meta,
+    negotiation_from_meta,
+    reset_current_negotiation,
+    set_current_negotiation,
+)
+from prometheus_mcp_server.spec2026.otel import (
+    extract_trace_headers,
+    reset_trace_headers,
+    set_trace_headers,
+)
+
+# The authoritative per-request ``_meta`` comes from the SDK's own request
+# context variable rather than from anything FastMCP rebuilt for itself.
+try:
+    from mcp.server.lowlevel.server import request_ctx as _sdk_request_ctx
+except Exception as e:  # pragma: no cover - requires an incompatible mcp SDK
+    logger.warning(
+        "MCP SDK request context unavailable; request _meta will not be read",
+        error=str(e),
+        error_type=type(e).__name__,
+    )
+    _sdk_request_ctx = None
+
+
+def _current_request_meta() -> Any:
+    """Read the raw ``_meta`` of the request currently being served.
+
+    Returns:
+        The SDK's ``RequestParams.Meta`` model, or None when no request is in
+        scope (the initialize handshake, or an internal FastMCP call such as a
+        tool-listing cache refresh).
+    """
+    if _sdk_request_ctx is None:
+        return None
+    try:
+        return getattr(_sdk_request_ctx.get(), "meta", None)
+    except LookupError:
+        return None
+    except Exception as e:
+        logger.warning(
+            "Could not read the SDK request context",
+            error=str(e),
+            error_type=type(e).__name__,
+        )
+        return None
+
+
+_NEGOTIATION_WRAPPER_MARKER = "_spec2026_negotiation_inner"
+
+#: Markers stamped on the low-level request handlers by this layer, innermost
+#: last. Used to unwrap a handler back to the SDK's own callable so a repeated
+#: install replaces rather than stacks.
+_SPEC_2026_WRAPPER_MARKERS = (_ENVELOPE_WRAPPER_MARKER, _NEGOTIATION_WRAPPER_MARKER)
+
+
+def _unwrap_spec_2026_handler(handler: Any) -> Any:
+    """Strip every 2026-07-28 wrapper off a low-level request handler.
+
+    Args:
+        handler: The handler currently registered for a request type.
+
+    Returns:
+        The innermost handler, i.e. the one the SDK or FastMCP registered.
+    """
+    while True:
+        for marker in _SPEC_2026_WRAPPER_MARKERS:
+            inner = getattr(handler, marker, None)
+            if inner is not None:
+                handler = inner
+                break
+        else:
+            return handler
+
+
+def _wrap_negotiation(handler: Any) -> Any:
+    """Build the per-request negotiation wrapper around a low-level handler.
+
+    Negotiation deliberately lives *below* FastMCP rather than in a FastMCP
+    middleware. FastMCP renders an exception raised during ``tools/call`` as a
+    successful ``CallToolResult`` with ``isError: true``, which would strip the
+    -32022 code and the ``data.supported`` list a client needs in order to
+    renegotiate. Raising from the low-level request handler produces a real
+    JSON-RPC error for every method alike.
+
+    Args:
+        handler: The original ``async (req) -> ServerResult`` handler.
+
+    Returns:
+        A coroutine function stamped with the negotiation wrapper marker.
+    """
+
+    async def negotiation_handler(req: Any = None) -> Any:
+        """Negotiate the request, publish its state, then run the handler."""
+        meta = extract_request_meta({"_meta": _current_request_meta()})
+
+        try:
+            negotiation = negotiation_from_meta(meta)
+        except NegotiationError as e:
+            logger.warning(
+                "Rejecting request after failed protocol negotiation",
+                code=e.code,
+                error=e.message,
+            )
+            raise e.to_mcp_error() from e
+
+        negotiation_token = set_current_negotiation(negotiation)
+        trace_token = set_trace_headers(extract_trace_headers(meta))
+        try:
+            result = handler(req)
+            if inspect.isawaitable(result):
+                result = await result
+            return result
+        finally:
+            # Capabilities are per-request and MUST NOT leak into the next one.
+            reset_current_negotiation(negotiation_token)
+            reset_trace_headers(trace_token)
+
+    setattr(negotiation_handler, _NEGOTIATION_WRAPPER_MARKER, handler)
+    return negotiation_handler
+
+
+def install_negotiation(server: Any = None) -> bool:
+    """Wrap a FastMCP server's request handlers with per-request negotiation.
+
+    Under 2026-07-28 a client restates its protocol version, capabilities and
+    trace context on every request inside ``params._meta`` rather than once at
+    initialize time. Each wrapped handler parses that block, rejects a protocol
+    version the server does not speak, and publishes the result on context
+    variables that downstream code (notably ``make_prometheus_request``) reads
+    without any threading of parameters. Both variables are reset in a
+    ``finally`` block so nothing survives into the next request.
+
+    Idempotent: an already-wrapped handler is unwrapped and re-wrapped rather
+    than nested, so repeated calls never stack duplicate negotiation passes.
+    Unwrapping strips the result envelope too, so this must run *before*
+    ``install_envelope`` -- which is the order ``install_spec_2026`` uses, and
+    which also puts negotiation innermost where the SDK's own request context is
+    still in scope.
+
+    Fully defensive: any unexpected SDK shape is logged and the server is left
+    exactly as it was. This function never raises.
+
+    Args:
+        server: The FastMCP server instance. Defaults to this module's server.
+
+    Returns:
+        True if at least one handler was wrapped, False if the layer degraded.
+    """
+    try:
+        handlers = _get_request_handlers(server if server is not None else mcp)
+        if handlers is None:
+            return False
+
+        wrapped_count = 0
+        for request_type in list(handlers.keys()):
+            inner = _unwrap_spec_2026_handler(handlers[request_type])
+            if not callable(inner):
+                logger.warning(
+                    "Skipping non-callable request handler",
+                    request_type=getattr(request_type, "__name__", repr(request_type)),
+                )
+                continue
+            handlers[request_type] = _wrap_negotiation(inner)
+            wrapped_count += 1
+
+        if wrapped_count == 0:
+            logger.warning("Negotiation wrapped no request handlers; layer inactive")
+            return False
+
+        logger.info("MCP 2026-07-28 negotiation installed", handler_count=wrapped_count)
+        return True
+
+    except Exception as e:
+        logger.warning(
+            "Per-request negotiation unavailable; server continues on 2025-11-25",
+            error=str(e),
+            error_type=type(e).__name__,
+        )
+        return False
+
+
+async def tool_header_annotations(tool_name: Any) -> List[Any]:
+    """Collect the ``x-mcp-header`` annotations declared by a tool's input schema.
+
+    Args:
+        tool_name: Name of the tool being called.
+
+    Returns:
+        The tool's validated header annotations, empty when the tool cannot be
+        resolved or declares none.
+    """
+    if not isinstance(tool_name, str):
+        return []
+    return await tool_annotation_lookup(mcp, tool_name)
+
+
+def strict_header_asgi_middleware() -> Any:
+    """Build the ASGI middleware enforcing the ``Mcp-*`` header rules (F6).
+
+    Strict validation happens at the ASGI layer because that is the only place
+    that still sees the exact JSON-RPC body the client sent -- FastMCP re-enters
+    its own middleware chain with internal sub-requests, and the SDK normalises
+    a ``params.uri`` before any FastMCP hook runs -- and the only place that can
+    still choose the HTTP status the design requires (400).
+
+    Returns:
+        A Starlette ``Middleware`` entry for ``FastMCP.run(middleware=[...])``,
+        or None when strict validation is switched off or unavailable.
+    """
+    if not config.strict_headers:
+        return None
+    try:
+        return strict_header_middleware(annotation_lookup=tool_header_annotations)
+    except Exception as e:
+        logger.warning(
+            "Strict header validation unavailable; requests will not be checked",
+            error=str(e),
+            error_type=type(e).__name__,
+        )
+        return None
+
+
+def install_spec_2026() -> Dict[str, Any]:
+    """Install the MCP 2026-07-28 compatibility layer onto this module's server.
+
+    Each piece is installed independently and every failure mode degrades to a
+    logged warning, so a future SDK release can disable the layer but can never
+    stop the server from serving 2025-11-25 clients. Every installer is
+    idempotent, so calling this twice (as the test-suite does) neither stacks
+    wrappers nor registers anything twice.
+
+    Returns:
+        Mapping of layer name to whether that piece was installed.
+    """
+    status: Dict[str, Any] = {
+        "negotiation": False,
+        "discovery": {},
+        "envelope": False,
+        "initialize_envelope": False,
+    }
+
+    try:
+        # Discovery first, so the negotiation and envelope wrappers installed
+        # below also cover the server/discover handler it registers.
+        status["discovery"] = install_discovery(
+            mcp,
+            mcp_name,
+            SERVER_VERSION,
+            tool_namer=_tool_name,
+            cache_scope=config.cache_scope,
+        )
+
+        status["negotiation"] = install_negotiation(mcp)
+
+        status["envelope"] = install_envelope(
+            mcp,
+            server_name=mcp_name,
+            server_version=SERVER_VERSION,
+            ttl_ms=config.cache_ttl_ms,
+            cache_scope=config.cache_scope,
+        )
+
+        # The SDK answers initialize inside ServerSession, out of reach of the
+        # request-handler wrappers, so it needs its own installer.
+        status["initialize_envelope"] = install_initialize_envelope(
+            server_name=mcp_name,
+            server_version=SERVER_VERSION,
+        )
+
+        logger.info(
+            "MCP 2026-07-28 compatibility layer installed",
+            strict_headers=config.strict_headers,
+            **status,
+        )
+    except Exception as e:
+        logger.warning(
+            "MCP 2026-07-28 compatibility layer unavailable; server continues on 2025-11-25",
+            error=str(e),
+            error_type=type(e).__name__,
+        )
+
+    return status
+
+
+if config.spec_2026_enabled:
+    SPEC_2026_STATUS = install_spec_2026()
+else:
+    SPEC_2026_STATUS = {}
+    logger.info(
+        "MCP 2026-07-28 compatibility layer disabled",
+        switch="PROMETHEUS_MCP_SPEC_2026",
+    )
+
 
 if __name__ == "__main__":
     logger.info("Starting Prometheus MCP Server", mode="direct")

--- a/src/prometheus_mcp_server/spec2026/__init__.py
+++ b/src/prometheus_mcp_server/spec2026/__init__.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python
+
+"""MCP 2026-07-28 server-side compatibility layer.
+
+The installed ``mcp`` SDK implements protocol ``2025-11-25`` and knows nothing
+about the 2026-07-28 revision, so every 2026-07-28 concept this server speaks is
+built here on top of the SDK rather than imported from it.
+
+The layer is split into six modules, each of which is importable on its own and
+none of which raises at import time even if the SDK's internals change:
+
+``constants``
+    Protocol versions, ``_meta`` key names, JSON-RPC error codes and envelope
+    literals. Pure data, no logic, stdlib-only.
+``envelope``
+    F2/F3. Wraps the low-level ``request_handlers`` so every result carries
+    ``resultType``, ``_meta`` serverInfo and (for cacheable methods)
+    ``ttlMs``/``cacheScope``, and so listable collections are returned sorted.
+``discovery``
+    F4/F8. Registers ``server/discover`` as a real JSON-RPC method, as a plain
+    ``GET /server/discover`` HTTP route, and as an MCP tool, all fed by one
+    payload factory.
+``negotiation``
+    F5. Parses per-request ``_meta`` (protocol version, client capabilities,
+    client info, log level) and publishes it on a ``ContextVar`` for the
+    duration of the request.
+``headers``
+    F6. Base64 sentinel codec, ``Mcp-*`` header/body validation, and
+    ``x-mcp-header`` input-schema annotation support.
+``otel``
+    F7. Extracts W3C trace context from a request's ``_meta`` and exposes it as
+    outbound HTTP headers.
+
+Everything is additive: a 2025-11-25 client sees the same server it always did.
+The whole layer is gated behind ``PROMETHEUS_MCP_SPEC_2026`` (default on).
+"""
+
+from prometheus_mcp_server.spec2026.constants import (
+    CACHE_SCOPE_PRIVATE,
+    CACHE_SCOPE_PUBLIC,
+    CACHE_SCOPES,
+    CACHEABLE_METHODS,
+    DEFAULT_CACHE_TTL_MS,
+    DISCOVER_CACHE_TTL_MS,
+    HEADER_MISMATCH,
+    INVALID_PARAMS,
+    META_BAGGAGE,
+    META_CLIENT_CAPABILITIES,
+    META_CLIENT_INFO,
+    META_LOG_LEVEL,
+    META_NAMESPACE,
+    META_PROTOCOL_VERSION,
+    META_SERVER_INFO,
+    META_SUBSCRIPTION_ID,
+    META_TRACEPARENT,
+    META_TRACESTATE,
+    METHOD_SERVER_DISCOVER,
+    MISSING_REQUIRED_CLIENT_CAPABILITY,
+    OTEL_META_KEYS,
+    PROTOCOL_VERSION_2025_06,
+    PROTOCOL_VERSION_2025_11,
+    PROTOCOL_VERSION_2026,
+    RESULT_TYPE_COMPLETE,
+    RESULT_TYPE_INPUT_REQUIRED,
+    RESULT_TYPES,
+    SUPPORTED_PROTOCOL_VERSIONS,
+    UNSUPPORTED_PROTOCOL_VERSION,
+)
+from prometheus_mcp_server.spec2026.asgi import (
+    StrictHeaderMiddleware,
+    strict_header_middleware,
+    tool_annotation_lookup,
+)
+from prometheus_mcp_server.spec2026.discovery import (
+    DISCOVER_METHOD,
+    DISCOVER_ROUTE_PATH,
+    DISCOVER_TOOL_BASE_NAME,
+    build_discover_payload,
+    install_discovery,
+)
+from prometheus_mcp_server.spec2026.envelope import (
+    enrich_result,
+    install_envelope,
+    install_initialize_envelope,
+    uninstall_envelope,
+    uninstall_initialize_envelope,
+)
+from prometheus_mcp_server.spec2026.headers import (
+    HeaderAnnotation,
+    is_safe_plain_ascii,
+    HeaderValidationError,
+    SchemaAnnotationError,
+    collect_header_annotations,
+    decode_header_value,
+    encode_header_value,
+    extract_param_headers,
+    header_mismatch_error,
+    validate_header_annotations,
+    validate_request_headers,
+)
+from prometheus_mcp_server.spec2026.negotiation import (
+    NegotiationError,
+    RequestNegotiation,
+    UnsupportedProtocolVersionError,
+    clear_current_negotiation,
+    current_log_level,
+    extract_request_meta,
+    get_current_negotiation,
+    may_emit_log_notifications,
+    negotiate_request,
+    negotiation_scope,
+)
+from prometheus_mcp_server.spec2026.otel import (
+    clear_trace_headers,
+    extract_trace_headers,
+    get_trace_headers,
+    reset_trace_headers,
+    set_trace_headers,
+    trace_context,
+)
+
+__all__ = [
+    # constants
+    "CACHEABLE_METHODS",
+    "CACHE_SCOPES",
+    "CACHE_SCOPE_PRIVATE",
+    "CACHE_SCOPE_PUBLIC",
+    "DEFAULT_CACHE_TTL_MS",
+    "DISCOVER_CACHE_TTL_MS",
+    "HEADER_MISMATCH",
+    "INVALID_PARAMS",
+    "METHOD_SERVER_DISCOVER",
+    "META_BAGGAGE",
+    "META_CLIENT_CAPABILITIES",
+    "META_CLIENT_INFO",
+    "META_LOG_LEVEL",
+    "META_NAMESPACE",
+    "META_PROTOCOL_VERSION",
+    "META_SERVER_INFO",
+    "META_SUBSCRIPTION_ID",
+    "META_TRACEPARENT",
+    "META_TRACESTATE",
+    "MISSING_REQUIRED_CLIENT_CAPABILITY",
+    "OTEL_META_KEYS",
+    "PROTOCOL_VERSION_2025_06",
+    "PROTOCOL_VERSION_2025_11",
+    "PROTOCOL_VERSION_2026",
+    "RESULT_TYPES",
+    "RESULT_TYPE_COMPLETE",
+    "RESULT_TYPE_INPUT_REQUIRED",
+    "SUPPORTED_PROTOCOL_VERSIONS",
+    "UNSUPPORTED_PROTOCOL_VERSION",
+    # discovery (F4/F8)
+    "DISCOVER_METHOD",
+    "DISCOVER_ROUTE_PATH",
+    "DISCOVER_TOOL_BASE_NAME",
+    "build_discover_payload",
+    "install_discovery",
+    # envelope (F2/F3)
+    "enrich_result",
+    "install_envelope",
+    "install_initialize_envelope",
+    "uninstall_envelope",
+    "uninstall_initialize_envelope",
+    # headers (F6)
+    "HeaderAnnotation",
+    "StrictHeaderMiddleware",
+    "is_safe_plain_ascii",
+    "strict_header_middleware",
+    "tool_annotation_lookup",
+    "HeaderValidationError",
+    "SchemaAnnotationError",
+    "collect_header_annotations",
+    "decode_header_value",
+    "encode_header_value",
+    "extract_param_headers",
+    "header_mismatch_error",
+    "validate_header_annotations",
+    "validate_request_headers",
+    # negotiation (F5)
+    "NegotiationError",
+    "RequestNegotiation",
+    "UnsupportedProtocolVersionError",
+    "clear_current_negotiation",
+    "current_log_level",
+    "extract_request_meta",
+    "get_current_negotiation",
+    "may_emit_log_notifications",
+    "negotiate_request",
+    "negotiation_scope",
+    # otel (F7)
+    "clear_trace_headers",
+    "extract_trace_headers",
+    "get_trace_headers",
+    "reset_trace_headers",
+    "set_trace_headers",
+    "trace_context",
+]

--- a/src/prometheus_mcp_server/spec2026/asgi.py
+++ b/src/prometheus_mcp_server/spec2026/asgi.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python
+
+"""ASGI-level strict ``Mcp-*`` header validation for MCP 2026-07-28 (F6).
+
+Header validation belongs at the ASGI layer and nowhere else, for three reasons
+that were each proven by a failing request first:
+
+1. **The body must be the bytes the client sent.** FastMCP re-enters its own
+   middleware chain with internal sub-requests (a cold ``tools/call`` triggers an
+   internal ``tools/list`` to warm the tool cache). Validating FastMCP's
+   per-hop view of "the request" against the real HTTP headers compares a
+   ``tools/list`` body with a ``Mcp-Method: tools/call`` header and rejects a
+   perfectly correct request -- but only on the first call, before the cache is
+   warm. The raw ASGI body has no such ambiguity.
+2. **A ``params.uri`` must be compared as sent.** By the time the SDK has parsed
+   the request, a URI has been round-tripped through ``pydantic.AnyUrl`` and
+   normalised, so it no longer matches the header the client mirrored it into.
+3. **The design requires HTTP 400.** Only the ASGI layer still owns the status
+   code; from inside the JSON-RPC dispatch the response is already committed to
+   HTTP 200.
+
+The middleware is **opt-in** (``PROMETHEUS_MCP_STRICT_HEADERS``) and inert for
+everything it does not understand: non-POST requests, non-JSON bodies,
+unparseable JSON and JSON-RPC batches are all forwarded untouched, so a
+misconfiguration can only ever fail open.
+
+Standard library plus Starlette (already a FastMCP dependency) only.
+"""
+
+import json
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Sequence
+
+from prometheus_mcp_server.logging_config import get_logger
+from prometheus_mcp_server.spec2026.headers import (
+    HeaderAnnotation,
+    collect_header_annotations,
+    header_mismatch_error,
+    validate_request_headers,
+)
+
+logger = get_logger()
+
+#: Largest request body this middleware will buffer before giving up and
+#: forwarding unvalidated. A JSON-RPC request that big is not a routing hint
+#: problem, and buffering it would be a memory-exhaustion vector.
+MAX_BUFFERED_BODY_BYTES = 1024 * 1024
+
+#: HTTP status for a header/body disagreement (design feature F6).
+HEADER_MISMATCH_STATUS = 400
+
+
+async def _read_body(
+    receive: Callable[[], Awaitable[Dict[str, Any]]],
+) -> "tuple[List[Dict[str, Any]], bool]":
+    """Buffer the whole request body, returning the raw ASGI messages.
+
+    Args:
+        receive: The ASGI receive callable.
+
+    Returns:
+        Tuple of (every message consumed, whether the body was read in full).
+        The messages are always returned so the caller can replay them
+        downstream even when validation has to be skipped.
+    """
+    messages: List[Dict[str, Any]] = []
+    size = 0
+    while True:
+        message = await receive()
+        messages.append(message)
+        if message.get("type") != "http.request":
+            # http.disconnect: nothing to validate, let the app handle it.
+            return messages, False
+        size += len(message.get("body", b"") or b"")
+        if size > MAX_BUFFERED_BODY_BYTES:
+            logger.warning(
+                "Request body too large for strict header validation; forwarding unvalidated",
+                max_bytes=MAX_BUFFERED_BODY_BYTES,
+            )
+            return messages, False
+        if not message.get("more_body", False):
+            return messages, True
+
+
+def _replay(
+    messages: Sequence[Dict[str, Any]],
+    original: Callable[[], Awaitable[Dict[str, Any]]],
+) -> Callable[[], Awaitable[Dict[str, Any]]]:
+    """Build a receive callable that replays already-consumed ASGI messages.
+
+    Once the buffer is drained the original callable takes over again. That
+    matters for more than tidiness: a streaming response polls ``receive`` to
+    notice ``http.disconnect``, so synthesising a reply here would spin that
+    poll into a busy loop and starve the event loop instead of streaming.
+
+    Args:
+        messages: Messages read off the original receive callable.
+        original: The receive callable the messages were read from.
+
+    Returns:
+        A receive callable yielding the buffered messages, then delegating.
+    """
+    pending = list(messages)
+
+    async def receive() -> Dict[str, Any]:
+        """Yield the next buffered message, then defer to the real stream."""
+        if pending:
+            return pending.pop(0)
+        return await original()
+
+    return receive
+
+
+def _headers_from_scope(scope: Dict[str, Any]) -> Dict[str, str]:
+    """Decode the ASGI raw header list into a plain string mapping.
+
+    Args:
+        scope: The ASGI connection scope.
+
+    Returns:
+        Mapping of lowercased header name to value. Repeated headers keep the
+        last value, matching the way the header hints are meant to be read.
+    """
+    headers: Dict[str, str] = {}
+    for raw_name, raw_value in scope.get("headers") or ():
+        try:
+            headers[raw_name.decode("latin-1").lower()] = raw_value.decode("latin-1")
+        except Exception:  # pragma: no cover - ASGI servers always hand over bytes
+            continue
+    return headers
+
+
+class StrictHeaderMiddleware:
+    """Reject an HTTP request whose ``Mcp-*`` headers contradict its body.
+
+    Args:
+        app: The next ASGI application in the chain.
+        annotation_lookup: Optional async callable mapping a tool name to its
+            validated ``x-mcp-header`` annotations, used to check the
+            ``Mcp-Param-*`` headers of a ``tools/call``. Omitted or failing
+            lookups simply skip the parameter headers.
+    """
+
+    def __init__(
+        self,
+        app: Any,
+        annotation_lookup: Optional[Callable[[str], Awaitable[Sequence[HeaderAnnotation]]]] = None,
+    ) -> None:
+        """Store the downstream app and the tool-annotation resolver."""
+        self.app = app
+        self.annotation_lookup = annotation_lookup
+
+    async def __call__(self, scope: Dict[str, Any], receive: Any, send: Any) -> None:
+        """Validate the request, then run the rest of the ASGI chain.
+
+        Args:
+            scope: The ASGI connection scope.
+            receive: The ASGI receive callable.
+            send: The ASGI send callable.
+
+        Returns:
+            None
+        """
+        if scope.get("type") != "http" or scope.get("method") != "POST":
+            await self.app(scope, receive, send)
+            return
+
+        messages, complete = await _read_body(receive)
+        replay = _replay(messages, receive)
+        if not complete:
+            await self.app(scope, replay, send)
+            return
+
+        body = b"".join(message.get("body", b"") or b"" for message in messages)
+
+        errors = await self._validate(scope, body)
+        if not errors:
+            await self.app(scope, replay, send)
+            return
+
+        await self._reject(body, errors, send)
+
+    async def _validate(self, scope: Dict[str, Any], body: bytes) -> List[Any]:
+        """Validate one buffered request body against its HTTP headers.
+
+        Args:
+            scope: The ASGI connection scope.
+            body: The raw request body.
+
+        Returns:
+            The header validation findings; empty when there is nothing to
+            reject, including every case this middleware does not understand.
+        """
+        try:
+            payload = json.loads(body)
+        except Exception:
+            # Not JSON, or truncated. The transport will produce its own error.
+            return []
+
+        if not isinstance(payload, dict) or "method" not in payload:
+            # A batch, a response, or a notification: nothing to validate.
+            return []
+
+        annotations: Sequence[HeaderAnnotation] = ()
+        if payload.get("method") == "tools/call" and self.annotation_lookup is not None:
+            params = payload.get("params")
+            name = params.get("name") if isinstance(params, dict) else None
+            if isinstance(name, str):
+                try:
+                    annotations = await self.annotation_lookup(name)
+                except Exception as e:
+                    logger.warning(
+                        "Could not resolve tool header annotations; skipping Mcp-Param checks",
+                        tool_name=name,
+                        error=str(e),
+                        error_type=type(e).__name__,
+                    )
+
+        return validate_request_headers(
+            _headers_from_scope(scope),
+            payload,
+            strict=True,
+            header_annotations=annotations,
+        )
+
+    async def _reject(self, body: bytes, errors: Sequence[Any], send: Any) -> None:
+        """Send the HeaderMismatch response, ending the request.
+
+        Args:
+            body: The raw request body, used only to echo the JSON-RPC id.
+            errors: Findings from :func:`validate_request_headers`.
+            send: The ASGI send callable.
+
+        Returns:
+            None
+        """
+        request_id = None
+        try:
+            request_id = json.loads(body).get("id")
+        except Exception:  # pragma: no cover - the body already parsed once
+            pass
+
+        error = header_mismatch_error(errors)
+        payload = json.dumps({"jsonrpc": "2.0", "id": request_id, "error": error}).encode("utf-8")
+
+        logger.warning(
+            "Rejecting request with mismatched MCP headers",
+            status=HEADER_MISMATCH_STATUS,
+            mismatched_headers=[finding.header for finding in errors],
+        )
+
+        await send(
+            {
+                "type": "http.response.start",
+                "status": HEADER_MISMATCH_STATUS,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(payload)).encode("ascii")),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": payload, "more_body": False})
+
+
+def strict_header_middleware(
+    annotation_lookup: Optional[Callable[[str], Awaitable[Sequence[HeaderAnnotation]]]] = None,
+) -> Any:
+    """Build the Starlette middleware entry FastMCP's HTTP app expects.
+
+    Args:
+        annotation_lookup: Async callable resolving a tool name to its validated
+            ``x-mcp-header`` annotations.
+
+    Returns:
+        A ``starlette.middleware.Middleware`` wrapping
+        :class:`StrictHeaderMiddleware`, ready to pass to ``FastMCP.run`` or
+        ``FastMCP.http_app`` as ``middleware=[...]``.
+    """
+    from starlette.middleware import Middleware
+
+    return Middleware(StrictHeaderMiddleware, annotation_lookup=annotation_lookup)
+
+
+async def tool_annotation_lookup(mcp: Any, tool_name: str) -> List[HeaderAnnotation]:
+    """Resolve a tool's ``x-mcp-header`` annotations from a FastMCP registry.
+
+    Args:
+        mcp: The FastMCP server instance.
+        tool_name: Name of the tool being called.
+
+    Returns:
+        The tool's validated header annotations, empty when the tool cannot be
+        resolved or declares none.
+    """
+    try:
+        tool = await mcp.get_tool(tool_name)
+        return collect_header_annotations(getattr(tool, "parameters", None))
+    except Exception as e:
+        logger.warning(
+            "Could not resolve tool header annotations",
+            tool_name=tool_name,
+            error=str(e),
+            error_type=type(e).__name__,
+        )
+        return []
+
+
+__all__ = [
+    "HEADER_MISMATCH_STATUS",
+    "MAX_BUFFERED_BODY_BYTES",
+    "StrictHeaderMiddleware",
+    "strict_header_middleware",
+    "tool_annotation_lookup",
+]

--- a/src/prometheus_mcp_server/spec2026/constants.py
+++ b/src/prometheus_mcp_server/spec2026/constants.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python
+
+"""Protocol constants for the MCP 2026-07-28 compatibility layer.
+
+The installed ``mcp`` SDK advertises ``2025-11-25`` as its latest protocol
+version, so every 2026-07-28 concept used by this server is defined here rather
+than imported from the SDK. Keeping the literals in one module means the
+envelope, discovery, negotiation, header and OpenTelemetry modules cannot drift
+apart from one another.
+
+This module is intentionally free of logic and of any non-stdlib import so that
+importing it can never fail, regardless of which SDK version is installed.
+"""
+
+from typing import Final, FrozenSet, Tuple
+
+# ---------------------------------------------------------------------------
+# Protocol versions
+# ---------------------------------------------------------------------------
+
+#: The protocol revision this compatibility layer targets.
+PROTOCOL_VERSION_2026: Final[str] = "2026-07-28"
+
+#: The revision implemented natively by the installed ``mcp`` SDK.
+PROTOCOL_VERSION_2025_11: Final[str] = "2025-11-25"
+
+#: The previous revision, still spoken by older clients.
+PROTOCOL_VERSION_2025_06: Final[str] = "2025-06-18"
+
+#: Every revision this server accepts, newest first. A request that names a
+#: version outside this tuple is rejected with ``UNSUPPORTED_PROTOCOL_VERSION``;
+#: a request that names no version at all is treated as legacy and accepted.
+SUPPORTED_PROTOCOL_VERSIONS: Final[Tuple[str, ...]] = (
+    PROTOCOL_VERSION_2026,
+    PROTOCOL_VERSION_2025_11,
+    PROTOCOL_VERSION_2025_06,
+)
+
+# ---------------------------------------------------------------------------
+# ``_meta`` key names
+# ---------------------------------------------------------------------------
+
+#: Reserved prefix for keys defined by the MCP specification itself.
+META_NAMESPACE: Final[str] = "io.modelcontextprotocol/"
+
+#: Protocol revision the client is speaking on this particular request.
+META_PROTOCOL_VERSION: Final[str] = "io.modelcontextprotocol/protocolVersion"
+
+#: Client capabilities, declared per-request (never inferred from history).
+META_CLIENT_CAPABILITIES: Final[str] = "io.modelcontextprotocol/clientCapabilities"
+
+#: Client implementation name/version, declared per-request.
+META_CLIENT_INFO: Final[str] = "io.modelcontextprotocol/clientInfo"
+
+#: Server implementation name/version, echoed back on every result.
+META_SERVER_INFO: Final[str] = "io.modelcontextprotocol/serverInfo"
+
+#: Minimum severity the client wants ``notifications/message`` for. When this
+#: key is absent the server MUST NOT emit log notifications for the request.
+META_LOG_LEVEL: Final[str] = "io.modelcontextprotocol/logLevel"
+
+#: Identifier correlating a request with a client-side subscription.
+META_SUBSCRIPTION_ID: Final[str] = "io.modelcontextprotocol/subscriptionId"
+
+# W3C trace-context keys. These are unprefixed by design: the 2026-07-28 minor
+# change #2 reuses the wire names from the W3C Trace Context recommendation.
+META_TRACEPARENT: Final[str] = "traceparent"
+META_TRACESTATE: Final[str] = "tracestate"
+META_BAGGAGE: Final[str] = "baggage"
+
+#: Trace-context keys that may be forwarded onto outbound HTTP requests.
+OTEL_META_KEYS: Final[Tuple[str, ...]] = (
+    META_TRACEPARENT,
+    META_TRACESTATE,
+    META_BAGGAGE,
+)
+
+# ---------------------------------------------------------------------------
+# JSON-RPC error codes
+# ---------------------------------------------------------------------------
+
+#: An ``Mcp-*`` HTTP header disagrees with the JSON-RPC body it accompanies.
+HEADER_MISMATCH: Final[int] = -32020
+
+#: The request needs a client capability the client did not declare.
+MISSING_REQUIRED_CLIENT_CAPABILITY: Final[int] = -32021
+
+#: The request named a protocol version outside SUPPORTED_PROTOCOL_VERSIONS.
+UNSUPPORTED_PROTOCOL_VERSION: Final[int] = -32022
+
+#: Standard JSON-RPC invalid-params code. 2026-07-28 reuses this for
+#: resource-not-found, which earlier revisions reported as ``-32002``.
+INVALID_PARAMS: Final[int] = -32602
+
+#: Superseded resource-not-found code, kept for documentation of the change.
+LEGACY_RESOURCE_NOT_FOUND: Final[int] = -32002
+
+# ---------------------------------------------------------------------------
+# Result envelope
+# ---------------------------------------------------------------------------
+
+#: The result carries the full answer; no further interaction is required.
+RESULT_TYPE_COMPLETE: Final[str] = "complete"
+
+#: The server needs more input before it can complete the request.
+RESULT_TYPE_INPUT_REQUIRED: Final[str] = "input_required"
+
+#: Every legal value of the ``resultType`` envelope field.
+RESULT_TYPES: Final[Tuple[str, ...]] = (
+    RESULT_TYPE_COMPLETE,
+    RESULT_TYPE_INPUT_REQUIRED,
+)
+
+#: Results identical for every caller may be cached in a shared cache.
+CACHE_SCOPE_PUBLIC: Final[str] = "public"
+
+#: Results vary per caller and may only be cached per-client.
+CACHE_SCOPE_PRIVATE: Final[str] = "private"
+
+#: Every legal value of the ``cacheScope`` envelope field.
+CACHE_SCOPES: Final[Tuple[str, ...]] = (
+    CACHE_SCOPE_PUBLIC,
+    CACHE_SCOPE_PRIVATE,
+)
+
+#: Default lifetime advertised via ``ttlMs`` for cacheable results (5 minutes,
+#: matching the server's existing in-process metrics cache).
+DEFAULT_CACHE_TTL_MS: Final[int] = 300000
+
+#: Default lifetime advertised for ``server/discover``, which changes only when
+#: the server itself is redeployed (1 hour).
+DISCOVER_CACHE_TTL_MS: Final[int] = 3600000
+
+# ---------------------------------------------------------------------------
+# Method names
+# ---------------------------------------------------------------------------
+
+METHOD_SERVER_DISCOVER: Final[str] = "server/discover"
+METHOD_TOOLS_LIST: Final[str] = "tools/list"
+METHOD_TOOLS_CALL: Final[str] = "tools/call"
+METHOD_PROMPTS_LIST: Final[str] = "prompts/list"
+METHOD_RESOURCES_LIST: Final[str] = "resources/list"
+METHOD_RESOURCES_TEMPLATES_LIST: Final[str] = "resources/templates/list"
+METHOD_RESOURCES_READ: Final[str] = "resources/read"
+
+#: Methods whose results carry ``ttlMs`` and ``cacheScope``. Notably excludes
+#: ``tools/call``, whose results are never cacheable.
+CACHEABLE_METHODS: Final[FrozenSet[str]] = frozenset(
+    {
+        METHOD_SERVER_DISCOVER,
+        METHOD_TOOLS_LIST,
+        METHOD_PROMPTS_LIST,
+        METHOD_RESOURCES_LIST,
+        METHOD_RESOURCES_TEMPLATES_LIST,
+        METHOD_RESOURCES_READ,
+    }
+)
+
+__all__ = [
+    "CACHEABLE_METHODS",
+    "CACHE_SCOPES",
+    "CACHE_SCOPE_PRIVATE",
+    "CACHE_SCOPE_PUBLIC",
+    "DEFAULT_CACHE_TTL_MS",
+    "DISCOVER_CACHE_TTL_MS",
+    "HEADER_MISMATCH",
+    "INVALID_PARAMS",
+    "LEGACY_RESOURCE_NOT_FOUND",
+    "METHOD_PROMPTS_LIST",
+    "METHOD_RESOURCES_LIST",
+    "METHOD_RESOURCES_READ",
+    "METHOD_RESOURCES_TEMPLATES_LIST",
+    "METHOD_SERVER_DISCOVER",
+    "METHOD_TOOLS_CALL",
+    "METHOD_TOOLS_LIST",
+    "META_BAGGAGE",
+    "META_CLIENT_CAPABILITIES",
+    "META_CLIENT_INFO",
+    "META_LOG_LEVEL",
+    "META_NAMESPACE",
+    "META_PROTOCOL_VERSION",
+    "META_SERVER_INFO",
+    "META_SUBSCRIPTION_ID",
+    "META_TRACEPARENT",
+    "META_TRACESTATE",
+    "MISSING_REQUIRED_CLIENT_CAPABILITY",
+    "OTEL_META_KEYS",
+    "PROTOCOL_VERSION_2025_06",
+    "PROTOCOL_VERSION_2025_11",
+    "PROTOCOL_VERSION_2026",
+    "RESULT_TYPES",
+    "RESULT_TYPE_COMPLETE",
+    "RESULT_TYPE_INPUT_REQUIRED",
+    "SUPPORTED_PROTOCOL_VERSIONS",
+    "UNSUPPORTED_PROTOCOL_VERSION",
+]

--- a/src/prometheus_mcp_server/spec2026/discovery.py
+++ b/src/prometheus_mcp_server/spec2026/discovery.py
@@ -1,0 +1,595 @@
+#!/usr/bin/env python
+"""``server/discover`` support for the MCP 2026-07-28 compatibility layer (F4 + F8).
+
+The installed SDK (``mcp``) implements protocol ``2025-11-25`` and therefore has no
+notion of the ``server/discover`` method: ``mcp.types.ClientRequest`` is a pydantic
+``RootModel`` over a closed union of request models, and any method not present in that
+union is rejected by ``BaseSession._receive_loop`` with ``-32602`` long before the
+low-level server's dispatch table is consulted. There is no unknown-method hook.
+
+Real JSON-RPC dispatch **is** nonetheless achievable without forking the SDK, and it
+works on every transport (stdio, Streamable HTTP stateful/stateless, SSE, in-memory).
+The union is a plain ``A | B | C`` ``types.UnionType`` rather than a discriminated
+union, so appending a member in place and forcing a model rebuild makes pydantic's
+smart-union resolve ``{"method": "server/discover"}`` to our request model, while every
+existing method still resolves to exactly the class it did before. ``mcp.types.
+ServerResult`` is extended the same way so the response serializes without pydantic
+emitting ``PydanticSerializationUnexpectedValue`` warnings on every reply.
+
+Three delivery paths are registered, all fed by a *single* payload factory so they can
+never drift:
+
+1. ``server/discover`` as a real JSON-RPC method (all transports).
+2. ``GET /server/discover`` as a plain HTTP route (mirrors the existing ``/health``
+   route), which is also the only pre-handshake answer for HTTP clients.
+3. An MCP tool, so the payload stays reachable even if path 1 degrades.
+
+Known limitation: JSON-RPC ``server/discover`` still requires the ``initialize``
+handshake first, because ``ServerSession._received_request`` rejects any non-
+``initialize``/non-``ping`` request before initialization. Removing that gate would
+require a transport rewrite, which the design doc lists as a non-goal. Path 2 covers
+the pre-initialization case for HTTP clients.
+
+Forward compatibility: if a future SDK ships its own ``server/discover`` request model,
+the union is left untouched and the handler is keyed on the SDK's own class instead.
+Naively appending a second member with the same ``method`` literal would let smart-union
+pick the SDK's class, so our handler key would never match and the method would silently
+degrade to ``METHOD_NOT_FOUND``.
+
+Every piece of SDK introspection here is wrapped: an incompatible SDK degrades to a
+logged warning and a partially (or fully) unregistered layer, never an import-time crash.
+"""
+
+import copy
+import importlib
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Literal,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    get_args,
+    get_origin,
+)
+
+from prometheus_mcp_server.logging_config import get_logger
+
+logger = get_logger()
+
+# JSON-RPC method name defined by the 2026-07-28 specification.
+DISCOVER_METHOD = "server/discover"
+
+# Base name of the MCP tool mirroring the payload. Run through the caller-supplied
+# namer (see server.py's ``_tool_name``) so TOOL_PREFIX is honored.
+DISCOVER_TOOL_BASE_NAME = "server_discover"
+
+# Default HTTP route, alongside the existing ``/health`` route.
+DISCOVER_ROUTE_PATH = "/server/discover"
+
+# Attribute stamped on the FastMCP instance to make ``install_discovery`` idempotent.
+_INSTALLED_ATTR = "_spec2026_discovery_status"
+
+# Discovery results are long-lived; the design doc's reference payload uses one hour.
+DEFAULT_DISCOVER_TTL_MS = 3600000
+
+# The payload is identical for every caller, so "public" is the correct default. Callers
+# that front the server with per-user auth can pass cache_scope="private" instead.
+DEFAULT_CACHE_SCOPE = "public"
+_VALID_CACHE_SCOPES = ("public", "private")
+
+
+def _load_constants() -> Any:
+    """Import the shared spec2026 constants module, tolerating its absence."""
+    try:
+        return importlib.import_module("prometheus_mcp_server.spec2026.constants")
+    except Exception:
+        return None
+
+
+_constants = _load_constants()
+
+
+def _const(name: str, default: Any) -> Any:
+    """Read a spec2026 constant, falling back to a local literal from the design doc.
+
+    Args:
+        name: Attribute name on the constants module.
+        default: Value to use when the constants module is missing the attribute.
+
+    Returns:
+        The shared constant when available, otherwise the supplied default.
+    """
+    if _constants is None:
+        return default
+    return getattr(_constants, name, default)
+
+
+PROTOCOL_VERSION_2026: str = _const("PROTOCOL_VERSION_2026", "2026-07-28")
+SUPPORTED_PROTOCOL_VERSIONS: Tuple[str, ...] = tuple(
+    _const("SUPPORTED_PROTOCOL_VERSIONS", ("2026-07-28", "2025-11-25", "2025-06-18"))
+)
+META_SERVER_INFO: str = _const("META_SERVER_INFO", "io.modelcontextprotocol/serverInfo")
+RESULT_TYPE_COMPLETE: str = _const("RESULT_TYPE_COMPLETE", "complete")
+
+# Keys the 2026-07-28 discovery result is required to carry.
+DISCOVER_REQUIRED_KEYS: Tuple[str, ...] = (
+    "resultType",
+    "supportedVersions",
+    "capabilities",
+    "instructions",
+    "ttlMs",
+    "cacheScope",
+    "_meta",
+)
+
+
+# --------------------------------------------------------------------------------------
+# F4 / F8 — the payload
+# --------------------------------------------------------------------------------------
+
+def default_instructions(server_name: str) -> str:
+    """Build the default human-readable ``instructions`` string.
+
+    Args:
+        server_name: Display name of the MCP server.
+
+    Returns:
+        A sentence describing what the server offers.
+    """
+    return (
+        f"{server_name} is a read-only Model Context Protocol server for Prometheus. "
+        "Call tools/list to enumerate the available tools, then use them to run PromQL "
+        "instant and range queries, list metrics and their metadata, inspect scrape "
+        "targets, and check server health. All tools are read-only and idempotent."
+    )
+
+
+def build_discover_payload(
+    server_name: str,
+    server_version: str,
+    *,
+    supported_versions: Optional[Sequence[str]] = None,
+    capabilities: Optional[Mapping[str, Any]] = None,
+    extensions: Optional[Mapping[str, Any]] = None,
+    instructions: Optional[str] = None,
+    ttl_ms: int = DEFAULT_DISCOVER_TTL_MS,
+    cache_scope: str = DEFAULT_CACHE_SCOPE,
+) -> Dict[str, Any]:
+    """Build the ``server/discover`` result payload.
+
+    Pure and dependency-free: every input arrives as an argument, nothing is read from
+    module or process globals, and a freshly owned dict is returned on every call so
+    callers may mutate the result without affecting later ones.
+
+    Args:
+        server_name: Display name advertised in ``_meta`` serverInfo.
+        server_version: Version string advertised in ``_meta`` serverInfo.
+        supported_versions: Protocol versions to advertise, newest first. Defaults to
+            SUPPORTED_PROTOCOL_VERSIONS.
+        capabilities: Extra server capabilities merged over the ``{"tools": {}}`` base.
+        extensions: Value for the ``extensions`` capability (F8). The key is always
+            present in the output, defaulting to an empty object.
+        instructions: Human-readable usage guidance. Defaults to default_instructions().
+        ttl_ms: Cache lifetime in milliseconds. Must be a non-negative int;
+            anything else (including a bool or a float) falls back to
+            DEFAULT_DISCOVER_TTL_MS with a warning.
+        cache_scope: Either "public" or "private". Anything else falls back to
+            DEFAULT_CACHE_SCOPE.
+
+    Returns:
+        Dict carrying every key in DISCOVER_REQUIRED_KEYS.
+    """
+    resolved_capabilities: Dict[str, Any] = {"tools": {}}
+    if capabilities:
+        resolved_capabilities.update(copy.deepcopy(dict(capabilities)))
+    if extensions is not None:
+        resolved_capabilities["extensions"] = copy.deepcopy(dict(extensions))
+    # F8: the extensions capability is advertised unconditionally.
+    resolved_capabilities.setdefault("extensions", {})
+
+    # Deliberately identical to envelope._coerce_ttl_ms: a bare int() would
+    # truncate a float and let bool through as 0/1 (bool subclasses int), so the
+    # same misconfiguration would produce a different ttlMs in the discovery
+    # document than in the result envelope.
+    if isinstance(ttl_ms, bool) or not isinstance(ttl_ms, int) or ttl_ms < 0:
+        logger.warning(
+            "Invalid discover ttlMs, falling back to default",
+            ttl_ms=repr(ttl_ms),
+            default_ttl_ms=DEFAULT_DISCOVER_TTL_MS,
+        )
+        resolved_ttl_ms = DEFAULT_DISCOVER_TTL_MS
+    else:
+        resolved_ttl_ms = ttl_ms
+
+    resolved_cache_scope = cache_scope
+    if resolved_cache_scope not in _VALID_CACHE_SCOPES:
+        logger.warning(
+            "Invalid discover cacheScope, falling back to default",
+            cache_scope=repr(cache_scope),
+            default_cache_scope=DEFAULT_CACHE_SCOPE,
+        )
+        resolved_cache_scope = DEFAULT_CACHE_SCOPE
+
+    resolved_versions = list(
+        supported_versions if supported_versions is not None else SUPPORTED_PROTOCOL_VERSIONS
+    )
+
+    return {
+        "resultType": RESULT_TYPE_COMPLETE,
+        "supportedVersions": resolved_versions,
+        "capabilities": resolved_capabilities,
+        "instructions": instructions if instructions is not None else default_instructions(server_name),
+        "ttlMs": resolved_ttl_ms,
+        "cacheScope": resolved_cache_scope,
+        "_meta": {META_SERVER_INFO: {"name": server_name, "version": server_version}},
+    }
+
+
+# --------------------------------------------------------------------------------------
+# SDK models — defined defensively so an incompatible SDK cannot break import
+# --------------------------------------------------------------------------------------
+
+def _define_models() -> Tuple[type, type]:
+    """Define the request/result pydantic models mirroring the SDK's own shapes.
+
+    Returns:
+        Tuple of (DiscoverRequest, DiscoverResult) model classes.
+    """
+    from mcp.types import Request, RequestParams, Result
+    from pydantic import ConfigDict
+
+    class DiscoverRequestParams(RequestParams):
+        """Parameters for ``server/discover``; the spec defines none, so all are extra."""
+
+        model_config = ConfigDict(extra="allow")
+
+    class DiscoverRequest(Request[Optional[DiscoverRequestParams], Literal["server/discover"]]):
+        """``server/discover`` JSON-RPC request.
+
+        ``params`` must exist (may be None): ``RequestResponder.__init__`` dereferences
+        ``validated_request.root.params`` unconditionally.
+        """
+
+        method: Literal["server/discover"] = "server/discover"
+        params: Optional[DiscoverRequestParams] = None
+
+    class DiscoverResult(Result):
+        """``server/discover`` JSON-RPC result; all spec fields ride as extras."""
+
+        model_config = ConfigDict(extra="allow")
+
+    return DiscoverRequest, DiscoverResult
+
+
+DiscoverRequest: Optional[type] = None
+DiscoverResult: Optional[type] = None
+
+try:
+    DiscoverRequest, DiscoverResult = _define_models()
+except Exception as exc:  # pragma: no cover - requires an incompatible SDK
+    logger.warning(
+        "Unable to define server/discover models; JSON-RPC dispatch disabled",
+        error=str(exc),
+        error_type=type(exc).__name__,
+    )
+
+
+# --------------------------------------------------------------------------------------
+# Union surgery helpers
+# --------------------------------------------------------------------------------------
+
+def _union_members(root_model: Any) -> Tuple[Any, ...]:
+    """Return the current members of a pydantic RootModel's union annotation."""
+    annotation = root_model.model_fields["root"].annotation
+    return tuple(get_args(annotation))
+
+
+def _find_member_by_method(root_model: Any, method: str) -> Optional[type]:
+    """Find an existing union member already declaring the given JSON-RPC method.
+
+    Args:
+        root_model: A pydantic RootModel such as ``mcp.types.ClientRequest``.
+        method: JSON-RPC method name to look for.
+
+    Returns:
+        The matching member class, or None when the SDK does not know the method.
+    """
+    for member in _union_members(root_model):
+        model_fields = getattr(member, "model_fields", None)
+        if not model_fields:
+            continue
+        annotation = getattr(model_fields.get("method"), "annotation", None)
+        if get_origin(annotation) is Literal and method in get_args(annotation):
+            return member
+    return None
+
+
+def _extend_union(root_model: Any, member: type) -> None:
+    """Append a member to a RootModel's union annotation, rolling back on failure.
+
+    Args:
+        root_model: A pydantic RootModel such as ``mcp.types.ClientRequest``.
+        member: Model class to add to the union.
+
+    Returns:
+        None.
+    """
+    field = root_model.model_fields["root"]
+    original = field.annotation
+    field.annotation = original | member
+    try:
+        root_model.model_rebuild(force=True)
+    except Exception:
+        # Never leave the SDK's types half-mutated.
+        field.annotation = original
+        try:
+            root_model.model_rebuild(force=True)
+        except Exception:  # pragma: no cover - rebuild of the pristine union cannot fail
+            logger.error("Failed to restore original union annotation", model=getattr(root_model, "__name__", "?"))
+        raise
+
+
+# --------------------------------------------------------------------------------------
+# Delivery paths
+# --------------------------------------------------------------------------------------
+
+def make_discover_endpoint(payload_factory: Callable[[], Dict[str, Any]]) -> Callable[..., Any]:
+    """Build the ``GET /server/discover`` Starlette endpoint.
+
+    Args:
+        payload_factory: Zero-argument callable returning the discover payload.
+
+    Returns:
+        An async endpoint returning a JSONResponse, suitable for ``mcp.custom_route``.
+    """
+    from starlette.requests import Request as StarletteRequest
+    from starlette.responses import JSONResponse
+
+    async def discover_endpoint(request: StarletteRequest) -> JSONResponse:
+        """Serve the server/discover payload over plain HTTP."""
+        return JSONResponse(payload_factory())
+
+    return discover_endpoint
+
+
+def make_discover_tool(payload_factory: Callable[[], Dict[str, Any]]) -> Callable[..., Any]:
+    """Build the MCP tool function exposing the discover payload.
+
+    Args:
+        payload_factory: Zero-argument callable returning the discover payload.
+
+    Returns:
+        An async, zero-argument coroutine function returning the payload dict.
+    """
+
+    async def server_discover() -> Dict[str, Any]:
+        """Return this server's MCP 2026-07-28 discovery document.
+
+        Returns:
+            Supported protocol versions, capabilities, instructions and cache hints
+        """
+        return payload_factory()
+
+    return server_discover
+
+
+def _install_jsonrpc(mcp: Any, payload_factory: Callable[[], Dict[str, Any]]) -> bool:
+    """Register ``server/discover`` as a real JSON-RPC method on the low-level server.
+
+    Args:
+        mcp: The FastMCP instance.
+        payload_factory: Zero-argument callable returning the discover payload.
+
+    Returns:
+        True when the handler was registered, False when the SDK shape was unusable.
+    """
+    if DiscoverRequest is None or DiscoverResult is None:
+        logger.warning("server/discover JSON-RPC dispatch unavailable; models undefined")
+        return False
+
+    try:
+        import mcp.types as mcp_types
+
+        low_level = getattr(mcp, "_mcp_server", None)
+        handlers = getattr(low_level, "request_handlers", None)
+        if not isinstance(handlers, dict):
+            logger.warning(
+                "server/discover JSON-RPC dispatch unavailable; request_handlers missing",
+                low_level_type=type(low_level).__name__,
+            )
+            return False
+
+        # Forward compatibility: if the SDK already knows the method, key the handler on
+        # the SDK's own class instead of adding a competing union member.
+        request_key = _find_member_by_method(mcp_types.ClientRequest, DISCOVER_METHOD)
+        native = request_key is not None
+        if request_key is None:
+            _extend_union(mcp_types.ClientRequest, DiscoverRequest)
+            request_key = DiscoverRequest
+
+        if DiscoverResult not in _union_members(mcp_types.ServerResult):
+            _extend_union(mcp_types.ServerResult, DiscoverResult)
+
+        async def discover_handler(request: Any) -> Any:
+            """Handle a ``server/discover`` JSON-RPC request."""
+            return mcp_types.ServerResult(DiscoverResult.model_validate(payload_factory()))
+
+        handlers[request_key] = discover_handler
+        logger.info(
+            "Registered server/discover JSON-RPC handler",
+            handler_key=getattr(request_key, "__name__", str(request_key)),
+            sdk_native=native,
+        )
+        return True
+
+    except Exception as exc:
+        logger.warning(
+            "server/discover JSON-RPC dispatch unavailable; falling back to HTTP route and MCP tool",
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+        return False
+
+
+def _install_http_route(
+    mcp: Any,
+    payload_factory: Callable[[], Dict[str, Any]],
+    route_path: str,
+) -> bool:
+    """Register the plain ``GET /server/discover`` HTTP route.
+
+    Args:
+        mcp: The FastMCP instance.
+        payload_factory: Zero-argument callable returning the discover payload.
+        route_path: Path to serve the payload from.
+
+    Returns:
+        True when the route was registered, False otherwise.
+    """
+    try:
+        mcp.custom_route(route_path, methods=["GET"])(make_discover_endpoint(payload_factory))
+        logger.info("Registered server/discover HTTP route", path=route_path)
+        return True
+    except Exception as exc:
+        logger.warning(
+            "server/discover HTTP route unavailable",
+            path=route_path,
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+        return False
+
+
+def _install_tool(
+    mcp: Any,
+    payload_factory: Callable[[], Dict[str, Any]],
+    tool_namer: Callable[[str], str],
+    tool_base_name: str,
+) -> bool:
+    """Register the MCP tool mirroring the discover payload.
+
+    Args:
+        mcp: The FastMCP instance.
+        payload_factory: Zero-argument callable returning the discover payload.
+        tool_namer: Callable applying the server's TOOL_PREFIX convention to a base name.
+        tool_base_name: Unprefixed tool name.
+
+    Returns:
+        True when the tool was registered, False otherwise.
+    """
+    tool_name = tool_base_name
+    try:
+        tool_name = tool_namer(tool_base_name)
+        mcp.tool(
+            name=tool_name,
+            description=(
+                "Return this server's MCP 2026-07-28 discovery document, listing the "
+                "supported protocol versions, advertised capabilities, and cache hints"
+            ),
+            annotations={
+                "title": "Server Discovery",
+                "icon": "🧭",
+                "readOnlyHint": True,
+                "destructiveHint": False,
+                "idempotentHint": True,
+                "openWorldHint": True,
+            },
+        )(make_discover_tool(payload_factory))
+        logger.info("Registered server/discover MCP tool", tool_name=tool_name)
+        return True
+    except Exception as exc:
+        logger.warning(
+            "server/discover MCP tool unavailable",
+            tool_name=tool_name,
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+        return False
+
+
+def install_discovery(
+    mcp: Any,
+    server_name: str,
+    server_version: str,
+    *,
+    tool_namer: Optional[Callable[[str], str]] = None,
+    supported_versions: Optional[Sequence[str]] = None,
+    capabilities: Optional[Mapping[str, Any]] = None,
+    extensions: Optional[Mapping[str, Any]] = None,
+    instructions: Optional[str] = None,
+    ttl_ms: int = DEFAULT_DISCOVER_TTL_MS,
+    cache_scope: str = DEFAULT_CACHE_SCOPE,
+    tool_base_name: str = DISCOVER_TOOL_BASE_NAME,
+    route_path: str = DISCOVER_ROUTE_PATH,
+    payload_factory: Optional[Callable[[], Dict[str, Any]]] = None,
+) -> Dict[str, bool]:
+    """Install every ``server/discover`` delivery path on a FastMCP instance.
+
+    Idempotent: the resulting status is stamped on the FastMCP instance and returned
+    unchanged on subsequent calls, so a double import cannot register duplicate routes
+    or tools. Defensive: each path is installed independently inside its own guard, so
+    an SDK change degrades to a logged warning and a partial install rather than an
+    exception.
+
+    Args:
+        mcp: The FastMCP instance to install onto.
+        server_name: Display name advertised in ``_meta`` serverInfo.
+        server_version: Version string advertised in ``_meta`` serverInfo.
+        tool_namer: Callable applying the server's TOOL_PREFIX convention (server.py's
+            ``_tool_name``). Passed in rather than imported to avoid a circular import.
+            Defaults to using the base name unchanged.
+        supported_versions: Protocol versions to advertise. See build_discover_payload.
+        capabilities: Extra capabilities merged over the ``{"tools": {}}`` base.
+        extensions: Value for the ``extensions`` capability (F8).
+        instructions: Human-readable usage guidance.
+        ttl_ms: Cache lifetime in milliseconds for the discovery result.
+        cache_scope: Either "public" or "private".
+        tool_base_name: Unprefixed name for the MCP tool.
+        route_path: Path for the plain HTTP route.
+        payload_factory: Escape hatch overriding all payload arguments with a custom
+            zero-argument builder. All three delivery paths share it so they cannot drift.
+
+    Returns:
+        Mapping of delivery path name ("jsonrpc", "http_route", "tool") to whether that
+        path was successfully registered.
+    """
+    existing = getattr(mcp, _INSTALLED_ATTR, None)
+    if isinstance(existing, dict):
+        logger.debug("server/discover already installed; skipping", status=existing)
+        return existing
+
+    if payload_factory is None:
+
+        def payload_factory() -> Dict[str, Any]:
+            """Build a fresh discover payload from the configured arguments."""
+            return build_discover_payload(
+                server_name,
+                server_version,
+                supported_versions=supported_versions,
+                capabilities=capabilities,
+                extensions=extensions,
+                instructions=instructions,
+                ttl_ms=ttl_ms,
+                cache_scope=cache_scope,
+            )
+
+    status = {
+        "jsonrpc": _install_jsonrpc(mcp, payload_factory),
+        "http_route": _install_http_route(mcp, payload_factory, route_path),
+        "tool": _install_tool(mcp, payload_factory, tool_namer or (lambda name: name), tool_base_name),
+    }
+
+    try:
+        setattr(mcp, _INSTALLED_ATTR, status)
+    except Exception as exc:  # pragma: no cover - FastMCP instances accept attributes
+        logger.warning(
+            "Unable to record server/discover install status",
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+
+    logger.info("server/discover installed", **status)
+    return status

--- a/src/prometheus_mcp_server/spec2026/envelope.py
+++ b/src/prometheus_mcp_server/spec2026/envelope.py
@@ -1,0 +1,653 @@
+#!/usr/bin/env python
+
+"""Result envelope enrichment for MCP 2026-07-28 (design features F2 and F3).
+
+The installed ``mcp`` SDK implements protocol ``2025-11-25`` and knows nothing
+about the 2026-07-28 result envelope. This module adds it server-side by
+wrapping the low-level server's ``request_handlers`` -- the one place where
+every request type is turned into a ``ServerResult``.
+
+Two facts make this work, both verified against ``mcp==1.29.0``:
+
+1. ``mcp.types.Result`` is declared with ``model_config = {"extra": "allow"}``,
+   so assigning ``resultType`` / ``ttlMs`` / ``cacheScope`` onto a result
+   instance lands in ``__pydantic_extra__`` and serializes through to the wire
+   with no serializer warnings.
+2. Handlers return a ``ServerResult``, which is a pydantic ``RootModel`` union
+   wrapper. The concrete result (``ListToolsResult``, ``CallToolResult``, ...)
+   lives on ``.root`` and is held **by reference**, so mutating it in place is
+   visible in the response without rebuilding the wrapper.
+
+Everything here is additive: 2025-11-25 clients ignore the unknown fields.
+"""
+
+import inspect
+from typing import Any, Callable, Dict, Optional, Tuple
+
+from prometheus_mcp_server.logging_config import get_logger
+
+logger = get_logger()
+
+try:
+    from prometheus_mcp_server.spec2026.constants import (
+        INVALID_PARAMS,
+        LEGACY_RESOURCE_NOT_FOUND,
+        META_SERVER_INFO,
+        RESULT_TYPE_COMPLETE,
+    )
+except Exception:  # pragma: no cover - constants.py is present; this is a safety net
+    # Values are fixed by the spec, so this module stays correct on its own even
+    # if constants.py is ever renamed or refactored. Never crash at import time.
+    INVALID_PARAMS = -32602
+    LEGACY_RESOURCE_NOT_FOUND = -32002
+    META_SERVER_INFO = "io.modelcontextprotocol/serverInfo"
+    RESULT_TYPE_COMPLETE = "complete"
+
+# Defaults per the design doc. 300000 ms mirrors the existing 300 s
+# ``_CACHE_TTL`` in server.py, but is deliberately a separate symbol so the two
+# can diverge without breaking the tests that pin ``_CACHE_TTL == 300``.
+DEFAULT_CACHE_TTL_MS = 300000
+DEFAULT_CACHE_SCOPE = "public"
+
+VALID_CACHE_SCOPES = ("public", "private")
+
+# Methods whose results may carry ``ttlMs``/``cacheScope``. Notably absent:
+# ``tools/call``, whose result depends on arguments and live Prometheus state
+# and must never be cached by the client.
+CACHEABLE_METHODS = frozenset(
+    {
+        "server/discover",
+        "tools/list",
+        "prompts/list",
+        "resources/list",
+        "resources/templates/list",
+        "resources/read",
+    }
+)
+
+# Result collections that must be returned in a deterministic order (F3).
+SORTABLE_COLLECTIONS = ("tools", "prompts", "resources", "resourceTemplates")
+
+# Methods whose "not found" failure moved from -32002 to -32602 in 2026-07-28
+# (design feature F1). The SDK still raises the 2025-11-25 code.
+RESOURCE_NOT_FOUND_METHODS = frozenset({"resources/read"})
+
+# Attribute stamped on a wrapper holding the handler it wrapped. Presence marks
+# a handler as already enriched, which makes install_envelope idempotent.
+_WRAPPER_MARKER = "_spec2026_envelope_inner"
+
+
+def _coerce_ttl_ms(value: Any) -> int:
+    """Validate a ttlMs setting, falling back to the default when unusable.
+
+    Args:
+        value: Candidate time-to-live in milliseconds.
+
+    Returns:
+        A non-negative integer suitable for the ``ttlMs`` envelope field.
+    """
+    # bool is a subclass of int; True would otherwise sail through as ttlMs=1.
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        logger.warning(
+            "Invalid cache TTL for result envelope, using default",
+            ttl_ms=repr(value),
+            default_ttl_ms=DEFAULT_CACHE_TTL_MS,
+        )
+        return DEFAULT_CACHE_TTL_MS
+    return value
+
+
+def _coerce_cache_scope(value: Any) -> str:
+    """Validate a cacheScope setting, falling back to the default when unusable.
+
+    Args:
+        value: Candidate cache scope.
+
+    Returns:
+        Either ``"public"`` or ``"private"``.
+    """
+    if value in VALID_CACHE_SCOPES:
+        return value
+    logger.warning(
+        "Invalid cache scope for result envelope, using default",
+        cache_scope=repr(value),
+        default_cache_scope=DEFAULT_CACHE_SCOPE,
+    )
+    return DEFAULT_CACHE_SCOPE
+
+
+def _request_method(request_type: Any) -> Optional[str]:
+    """Read the JSON-RPC method string off an SDK request model class.
+
+    Every ``mcp.types`` request declares ``method: Literal["..."] = "..."``, so
+    the default of that field is the method name. A future SDK could change
+    that shape, hence the defensive read.
+
+    Args:
+        request_type: The request model class used as a request_handlers key.
+
+    Returns:
+        The method string, or None if it could not be determined.
+    """
+    try:
+        field = request_type.model_fields["method"]
+    except Exception:
+        return None
+    default = getattr(field, "default", None)
+    return default if isinstance(default, str) else None
+
+
+def _unwrap_result(result: Any) -> Any:
+    """Reach through a ``ServerResult`` RootModel to the concrete result.
+
+    Args:
+        result: A ``ServerResult`` wrapper or an already-unwrapped result.
+
+    Returns:
+        The concrete result model that carries the ``meta`` field.
+    """
+    root = getattr(result, "root", None)
+    return result if root is None else root
+
+
+def _sort_key(item: Any) -> Tuple[str, str]:
+    """Build a total, exception-free ordering key for a listable item.
+
+    Name is the primary key (spec minor change #3); the URI (or URI template)
+    breaks ties so ordering stays stable even for same-named entries.
+
+    Args:
+        item: A Tool, Prompt, Resource or ResourceTemplate model.
+
+    Returns:
+        A (name, uri) tuple of strings.
+    """
+    name = getattr(item, "name", None)
+    uri = getattr(item, "uri", None)
+    if uri is None:
+        uri = getattr(item, "uriTemplate", None)
+    return (str(name or ""), str(uri or ""))
+
+
+def _sort_collections(result: Any) -> None:
+    """Sort every known listable collection on a result in place.
+
+    Args:
+        result: The concrete result model to reorder.
+    """
+    for attribute in SORTABLE_COLLECTIONS:
+        items = getattr(result, attribute, None)
+        if isinstance(items, list) and len(items) > 1:
+            setattr(result, attribute, sorted(items, key=_sort_key))
+
+
+def _merge_server_info(result: Any, server_name: str, server_version: str) -> None:
+    """Merge serverInfo into a result's ``_meta`` without clobbering it.
+
+    Existing ``_meta`` keys are preserved, including an existing serverInfo
+    entry -- a handler that deliberately set one (the discover payload, for
+    instance) stays authoritative.
+
+    Args:
+        result: The concrete result model to enrich.
+        server_name: Server name to advertise.
+        server_version: Server version to advertise.
+    """
+    existing = getattr(result, "meta", None)
+    if existing is None:
+        meta: Dict[str, Any] = {}
+    elif isinstance(existing, dict):
+        meta = dict(existing)
+    else:
+        logger.warning(
+            "Result _meta is not a mapping, skipping serverInfo merge",
+            meta_type=type(existing).__name__,
+        )
+        return
+
+    meta.setdefault(META_SERVER_INFO, {"name": server_name, "version": server_version})
+    result.meta = meta
+
+
+def _is_unset(result: Any, field: str) -> bool:
+    """Return True when an envelope field is absent from a result.
+
+    Args:
+        result: The concrete result model.
+        field: Envelope field name.
+
+    Returns:
+        True if the field is missing or None.
+    """
+    return getattr(result, field, None) is None
+
+
+def enrich_result(
+    result: Any,
+    *,
+    method: Optional[str],
+    server_name: str,
+    server_version: str,
+    ttl_ms: int = DEFAULT_CACHE_TTL_MS,
+    cache_scope: str = DEFAULT_CACHE_SCOPE,
+) -> Any:
+    """Apply the 2026-07-28 envelope to a result, in place.
+
+    Adds ``resultType`` and ``_meta`` serverInfo to every result, plus
+    ``ttlMs``/``cacheScope`` when the method is in ``CACHEABLE_METHODS``, and
+    sorts any listable collection by name.
+
+    Fields that are already set are left alone, so the function is safe to
+    apply twice and a handler that produced its own envelope (for example a
+    non-``complete`` ``resultType``) keeps its values.
+
+    Args:
+        result: A ``ServerResult`` wrapper or a concrete result model.
+        method: The JSON-RPC method that produced the result, or None if
+            unknown (unknown methods are treated as non-cacheable).
+        server_name: Server name advertised in ``_meta`` serverInfo.
+        server_version: Server version advertised in ``_meta`` serverInfo.
+        ttl_ms: Cache lifetime in milliseconds for cacheable methods. Validated
+            here rather than trusted, because this function is public API and a
+            caller may pass an operator-supplied value straight through.
+        cache_scope: ``"public"`` or ``"private"`` for cacheable methods. Also
+            validated; anything else (including None) falls back to the default.
+
+    Returns:
+        The same object that was passed in, for convenience.
+    """
+    inner = _unwrap_result(result)
+
+    if _is_unset(inner, "resultType"):
+        inner.resultType = RESULT_TYPE_COMPLETE
+
+    if method in CACHEABLE_METHODS:
+        # Never emit a spec-invalid envelope: ttlMs MUST be an integer >= 0 and
+        # cacheScope MUST be "public" or "private".
+        if _is_unset(inner, "ttlMs"):
+            inner.ttlMs = _coerce_ttl_ms(ttl_ms)
+        if _is_unset(inner, "cacheScope"):
+            inner.cacheScope = _coerce_cache_scope(cache_scope)
+
+    _merge_server_info(inner, server_name, server_version)
+    _sort_collections(inner)
+    return result
+
+
+def _retype_error(error: Exception, method: Optional[str]) -> Exception:
+    """Rewrite a handler failure to the 2026-07-28 JSON-RPC error code (F1).
+
+    Only one code changed: ``resources/read`` reports a missing resource with
+    ``INVALID_PARAMS`` (-32602) instead of the 2025-11-25 ``-32002``. Anything
+    else is returned untouched.
+
+    Args:
+        error: The exception the wrapped handler raised.
+        method: The JSON-RPC method the handler serves.
+
+    Returns:
+        A replacement exception, or ``error`` itself when nothing changed.
+    """
+    if method not in RESOURCE_NOT_FOUND_METHODS:
+        return error
+
+    data = getattr(error, "error", None)
+    if getattr(data, "code", None) != LEGACY_RESOURCE_NOT_FOUND:
+        return error
+
+    try:
+        from mcp.shared.exceptions import McpError
+        from mcp.types import ErrorData
+
+        if not isinstance(error, McpError):
+            return error
+        return McpError(
+            ErrorData(
+                code=INVALID_PARAMS,
+                message=data.message,
+                data=getattr(data, "data", None),
+            )
+        )
+    except Exception as e:  # pragma: no cover - depends on SDK layout
+        logger.warning(
+            "Could not retype the resource-not-found error code",
+            method=method,
+            error=str(e),
+            error_type=type(e).__name__,
+        )
+        return error
+
+
+def _wrap_handler(
+    handler: Callable[..., Any],
+    *,
+    method: Optional[str],
+    server_name: str,
+    server_version: str,
+    ttl_ms: int,
+    cache_scope: str,
+) -> Callable[..., Any]:
+    """Build an envelope-applying wrapper around a low-level request handler.
+
+    Args:
+        handler: The original ``async (req) -> ServerResult`` handler.
+        method: The JSON-RPC method this handler serves, or None if unknown.
+        server_name: Server name advertised in ``_meta`` serverInfo.
+        server_version: Server version advertised in ``_meta`` serverInfo.
+        ttl_ms: Cache lifetime in milliseconds for cacheable methods.
+        cache_scope: ``"public"`` or ``"private"`` for cacheable methods.
+
+    Returns:
+        A coroutine function stamped with the wrapper marker.
+    """
+
+    async def envelope_handler(req: Any = None) -> Any:
+        # The SDK calls the tools/list handler with req=None when refreshing its
+        # internal tool cache, so req is never dereferenced here.
+        try:
+            result = handler(req)
+            if inspect.isawaitable(result):
+                result = await result
+        except Exception as e:
+            retyped = _retype_error(e, method)
+            if retyped is e:
+                raise
+            raise retyped from e
+        try:
+            enrich_result(
+                result,
+                method=method,
+                server_name=server_name,
+                server_version=server_version,
+                ttl_ms=ttl_ms,
+                cache_scope=cache_scope,
+            )
+        except Exception as e:
+            # A malformed envelope must never cost the client its response.
+            logger.warning(
+                "Failed to apply result envelope",
+                method=method,
+                error=str(e),
+                error_type=type(e).__name__,
+            )
+        return result
+
+    setattr(envelope_handler, _WRAPPER_MARKER, handler)
+    return envelope_handler
+
+
+def install_envelope(
+    mcp: Any,
+    *,
+    server_name: str,
+    server_version: str,
+    ttl_ms: int = DEFAULT_CACHE_TTL_MS,
+    cache_scope: str = DEFAULT_CACHE_SCOPE,
+) -> bool:
+    """Wrap a FastMCP server's request handlers with envelope enrichment.
+
+    Idempotent: an already-wrapped handler is unwrapped and re-wrapped rather
+    than nested, so repeated calls neither stack wrappers nor leave stale
+    settings behind. Calling it again after new handlers are registered (the
+    ``server/discover`` handler, for instance) picks those up too.
+
+    Fully defensive: any unexpected SDK shape is logged and the server is left
+    exactly as it was. This function never raises.
+
+    Args:
+        mcp: The FastMCP server instance.
+        server_name: Server name advertised in ``_meta`` serverInfo.
+        server_version: Server version advertised in ``_meta`` serverInfo.
+        ttl_ms: Cache lifetime in milliseconds; must be an int >= 0.
+        cache_scope: ``"public"`` or ``"private"``. Defaults to ``"public"``
+            because every list result on this server is identical for all
+            users -- tool, prompt and resource listings are static and carry no
+            per-tenant data, so a shared cache is both safe and the more useful
+            choice. Deployments that put per-tenant data behind auth should set
+            ``"private"`` via configuration.
+
+    Returns:
+        True if at least one handler was wrapped, False if the layer degraded.
+    """
+    try:
+        ttl_ms = _coerce_ttl_ms(ttl_ms)
+        cache_scope = _coerce_cache_scope(cache_scope)
+
+        handlers = _get_request_handlers(mcp)
+        if handlers is None:
+            return False
+
+        wrapped_count = 0
+        for request_type in list(handlers.keys()):
+            try:
+                handler = handlers[request_type]
+                # Unwrap first so a re-install replaces rather than nests.
+                inner = getattr(handler, _WRAPPER_MARKER, None)
+                if inner is None:
+                    inner = handler
+                if not callable(inner):
+                    logger.warning(
+                        "Skipping non-callable request handler",
+                        request_type=getattr(request_type, "__name__", repr(request_type)),
+                    )
+                    continue
+
+                method = _request_method(request_type)
+                if method is None:
+                    logger.debug(
+                        "Could not determine method for request handler; treating as non-cacheable",
+                        request_type=getattr(request_type, "__name__", repr(request_type)),
+                    )
+
+                handlers[request_type] = _wrap_handler(
+                    inner,
+                    method=method,
+                    server_name=server_name,
+                    server_version=server_version,
+                    ttl_ms=ttl_ms,
+                    cache_scope=cache_scope,
+                )
+                wrapped_count += 1
+            except Exception as e:
+                logger.warning(
+                    "Failed to wrap request handler for result envelope",
+                    request_type=getattr(request_type, "__name__", repr(request_type)),
+                    error=str(e),
+                    error_type=type(e).__name__,
+                )
+
+        if wrapped_count == 0:
+            logger.warning("Result envelope wrapped no request handlers; layer inactive")
+            return False
+
+        logger.info(
+            "MCP 2026-07-28 result envelope installed",
+            handler_count=wrapped_count,
+            ttl_ms=ttl_ms,
+            cache_scope=cache_scope,
+            server_name=server_name,
+            server_version=server_version,
+        )
+        return True
+
+    except Exception as e:
+        logger.warning(
+            "Result envelope unavailable; server continues without it",
+            error=str(e),
+            error_type=type(e).__name__,
+        )
+        return False
+
+
+def uninstall_envelope(mcp: Any) -> bool:
+    """Restore the original request handlers, removing envelope enrichment.
+
+    Primarily useful for tests, which share a module-level FastMCP singleton
+    and must not leak the wrappers into unrelated test modules. Like
+    ``install_envelope``, this never raises.
+
+    Args:
+        mcp: The FastMCP server instance.
+
+    Returns:
+        True if at least one handler was restored, False otherwise.
+    """
+    try:
+        handlers = _get_request_handlers(mcp)
+        if handlers is None:
+            return False
+
+        restored_count = 0
+        for request_type in list(handlers.keys()):
+            inner = getattr(handlers[request_type], _WRAPPER_MARKER, None)
+            if inner is not None:
+                handlers[request_type] = inner
+                restored_count += 1
+
+        if restored_count:
+            logger.info("MCP 2026-07-28 result envelope removed", handler_count=restored_count)
+        return restored_count > 0
+
+    except Exception as e:
+        logger.warning(
+            "Failed to remove result envelope",
+            error=str(e),
+            error_type=type(e).__name__,
+        )
+        return False
+
+
+# Attribute stamped on the patched ServerSession._received_request holding the
+# method it replaced. Presence marks the patch as already applied.
+_INIT_WRAPPER_MARKER = "_spec2026_initialize_envelope_inner"
+
+
+def install_initialize_envelope(*, server_name: str, server_version: str) -> bool:
+    """Extend the result envelope to cover the ``initialize`` handshake (F2).
+
+    ``InitializeRequest`` never reaches ``request_handlers``: the SDK answers it
+    inside ``ServerSession._received_request``, so :func:`install_envelope`
+    cannot see it and a 2026-07-28 client would receive at least one
+    envelope-less result on every connection. This wraps that one method and
+    enriches the ``InitializeResult`` on its way out.
+
+    Idempotent and fully defensive: a second call is a no-op and any unexpected
+    SDK shape is logged, leaving the session class untouched.
+
+    Note that ``ServerSession`` is a process-global class, so this patch covers
+    every MCP server running in the process, not just one FastMCP instance. That
+    is correct for this package (a single server per process) and is why
+    :func:`uninstall_initialize_envelope` exists.
+
+    Args:
+        server_name: Server name advertised in ``_meta`` serverInfo.
+        server_version: Server version advertised in ``_meta`` serverInfo.
+
+    Returns:
+        True when the handshake is now enveloped, False if the layer degraded.
+    """
+    try:
+        import mcp.types as mcp_types
+        from mcp.server.session import ServerSession
+
+        original = ServerSession._received_request
+        if getattr(original, _INIT_WRAPPER_MARKER, None) is not None:
+            return True
+
+        async def received_request(self: Any, responder: Any) -> Any:
+            """Enrich the InitializeResult before the responder sends it."""
+            root = getattr(getattr(responder, "request", None), "root", None)
+            if isinstance(root, mcp_types.InitializeRequest):
+                inner_respond = responder.respond
+
+                async def respond(response: Any) -> Any:
+                    """Apply the envelope, then hand the result to the SDK."""
+                    try:
+                        enrich_result(
+                            response,
+                            method="initialize",
+                            server_name=server_name,
+                            server_version=server_version,
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            "Failed to apply result envelope to the initialize handshake",
+                            error=str(e),
+                            error_type=type(e).__name__,
+                        )
+                    return await inner_respond(response)
+
+                responder.respond = respond
+            return await original(self, responder)
+
+        setattr(received_request, _INIT_WRAPPER_MARKER, original)
+        ServerSession._received_request = received_request
+        logger.info(
+            "MCP 2026-07-28 initialize envelope installed",
+            server_name=server_name,
+            server_version=server_version,
+        )
+        return True
+
+    except Exception as e:
+        logger.warning(
+            "Initialize envelope unavailable; the handshake result stays un-enveloped",
+            error=str(e),
+            error_type=type(e).__name__,
+        )
+        return False
+
+
+def uninstall_initialize_envelope() -> bool:
+    """Restore the SDK's own ``ServerSession._received_request``.
+
+    Mainly for tests, which share a process with every other test module and
+    must be able to observe the un-enveloped handshake. Never raises.
+
+    Returns:
+        True when a patch was removed, False when there was nothing to remove.
+    """
+    try:
+        from mcp.server.session import ServerSession
+
+        original = getattr(ServerSession._received_request, _INIT_WRAPPER_MARKER, None)
+        if original is None:
+            return False
+        ServerSession._received_request = original
+        logger.info("MCP 2026-07-28 initialize envelope removed")
+        return True
+    except Exception as e:  # pragma: no cover - requires an incompatible SDK
+        logger.warning(
+            "Failed to remove the initialize envelope",
+            error=str(e),
+            error_type=type(e).__name__,
+        )
+        return False
+
+
+def _get_request_handlers(mcp: Any) -> Optional[Dict[Any, Callable[..., Any]]]:
+    """Fetch the low-level server's request_handlers dict, defensively.
+
+    Args:
+        mcp: The FastMCP server instance.
+
+    Returns:
+        The mutable handler dict, or None if the SDK's shape was unexpected.
+    """
+    low_level = getattr(mcp, "_mcp_server", None)
+    if low_level is None:
+        logger.warning(
+            "FastMCP instance exposes no _mcp_server; result envelope unavailable",
+            mcp_type=type(mcp).__name__,
+        )
+        return None
+
+    handlers = getattr(low_level, "request_handlers", None)
+    if not isinstance(handlers, dict):
+        logger.warning(
+            "Low-level server exposes no request_handlers dict; result envelope unavailable",
+            handlers_type=type(handlers).__name__,
+        )
+        return None
+
+    return handlers

--- a/src/prometheus_mcp_server/spec2026/headers.py
+++ b/src/prometheus_mcp_server/spec2026/headers.py
@@ -1,0 +1,821 @@
+#!/usr/bin/env python
+
+"""HTTP header validation and ``x-mcp-header`` support for MCP 2026-07-28 (F6).
+
+This module implements three independent concerns of the 2026-07-28 header
+extension, all with standard library only:
+
+A. The base64 sentinel codec (``=?base64?{b64}?=``) used to transport header
+   values that are not safe plain ASCII.
+B. Validation of the ``Mcp-Method`` / ``Mcp-Name`` / ``MCP-Protocol-Version`` /
+   ``Mcp-Param-{Name}`` headers against the JSON-RPC request body, producing
+   ``HeaderMismatch`` (-32020) errors.
+C. Validation of the ``x-mcp-header`` annotation inside a tool ``inputSchema``,
+   plus extraction of the annotated values into outgoing headers.
+
+Strict enforcement is **opt-in**: :func:`validate_request_headers` is a no-op
+unless ``strict=True`` is passed, so 2025-11-25 clients that send no ``Mcp-*``
+headers at all keep working unchanged.
+
+The ``Mcp-*`` headers are *optional* routing hints. A client is never obliged to
+send one, so an absent header is never an error even when the body carries the
+corresponding value; ``HeaderMismatch`` is reserved for a header that actually
+disagrees with the body, or for one sent when the body has nothing to mirror.
+
+``MCP-Protocol-Version`` is deliberately treated differently from the ``Mcp-*``
+hints: it is a Streamable-HTTP *transport* header that the MCP specification has
+REQUIRED on every post-initialize HTTP request since 2025-06-18, not a mirror of
+a body field. See :func:`validate_request_headers` for the exact rule.
+"""
+
+import base64
+import binascii
+import os
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+from urllib.parse import urlsplit, urlunsplit
+
+from prometheus_mcp_server.logging_config import get_logger
+
+logger = get_logger()
+
+# The error code lives in the shared constants module, but this module must stay
+# importable on its own (and must not crash if constants.py is absent or a later
+# revision drops the symbol), so the literal is kept as a defensive fallback.
+try:  # pragma: no cover - exercised implicitly by whichever branch is installed
+    from prometheus_mcp_server.spec2026.constants import HEADER_MISMATCH
+except Exception:  # pragma: no cover - defensive: constants module not present yet
+    HEADER_MISMATCH = -32020
+
+try:  # pragma: no cover - exercised implicitly by whichever branch is installed
+    from prometheus_mcp_server.spec2026.constants import META_PROTOCOL_VERSION
+except Exception:  # pragma: no cover - defensive: constants module not present yet
+    META_PROTOCOL_VERSION = "io.modelcontextprotocol/protocolVersion"
+
+try:  # pragma: no cover - exercised implicitly by whichever branch is installed
+    from prometheus_mcp_server.spec2026.constants import PROTOCOL_VERSION_2026
+except Exception:  # pragma: no cover - defensive: constants module not present yet
+    PROTOCOL_VERSION_2026 = "2026-07-28"
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Sentinel markers are lowercase and compared case-sensitively.
+SENTINEL_PREFIX = "=?base64?"
+SENTINEL_SUFFIX = "?="
+
+#: Header carrying the JSON-RPC ``method`` of the body.
+HEADER_MCP_METHOD = "Mcp-Method"
+#: Header carrying ``params.name`` (or ``params.uri``) of the body.
+HEADER_MCP_NAME = "Mcp-Name"
+#: Header carrying the negotiated protocol version.
+HEADER_MCP_PROTOCOL_VERSION = "MCP-Protocol-Version"
+#: Prefix for headers generated from ``x-mcp-header`` annotations.
+PARAM_HEADER_PREFIX = "Mcp-Param-"
+
+#: JSON Schema keyword carrying the annotation.
+ANNOTATION_KEY = "x-mcp-header"
+
+#: Only these primitive types may be annotated. ``number`` is explicitly NOT
+#: permitted by the specification (float formatting is not interoperable).
+ALLOWED_ANNOTATION_TYPES = ("integer", "string", "boolean")
+
+#: RFC 9110 ``token`` = 1*tchar.
+_TCHAR = r"[!#$%&'*+\-.^_`|~0-9A-Za-z]"
+_TOKEN_RE = re.compile(r"\A" + _TCHAR + r"+\Z")
+
+#: Safe plain ASCII: tab, space, and the printable range 0x21-0x7E.
+_SAFE_CHARS = frozenset({"\t", " "} | {chr(code) for code in range(0x21, 0x7F)})
+
+#: The JSON number grammar (RFC 8259 section 6), anchored. Used instead of
+#: ``float()`` so header values that are not legal JSON numbers never compare
+#: equal to a numeric body value.
+_JSON_NUMBER_RE = re.compile(r"\A-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?(?:[eE][-+]?[0-9]+)?\Z")
+
+
+# ---------------------------------------------------------------------------
+# (A) Base64 sentinel codec
+# ---------------------------------------------------------------------------
+
+def looks_like_sentinel(value: str) -> bool:
+    """Report whether a string is shaped like an encoded sentinel value.
+
+    The markers are case-sensitive and must not overlap, so the value has to be
+    at least ``len(prefix) + len(suffix)`` characters long.
+
+    Args:
+        value: Raw header value to inspect.
+
+    Returns:
+        True when the value starts with ``=?base64?`` and ends with ``?=``
+        without the two markers overlapping.
+    """
+    if not isinstance(value, str):
+        return False
+    if len(value) < len(SENTINEL_PREFIX) + len(SENTINEL_SUFFIX):
+        return False
+    return value.startswith(SENTINEL_PREFIX) and value.endswith(SENTINEL_SUFFIX)
+
+
+def is_safe_plain_ascii(value: str) -> bool:
+    """Report whether a value may travel unencoded in an HTTP header.
+
+    A value is safe when every character is a tab, a space, or printable ASCII
+    (0x21-0x7E), it has no leading or trailing whitespace, and it is not itself
+    shaped like an encoded sentinel value (which would be ambiguous on decode).
+
+    Args:
+        value: Value to inspect.
+
+    Returns:
+        True when the value can be sent verbatim.
+    """
+    if not isinstance(value, str):
+        return False
+    if any(char not in _SAFE_CHARS for char in value):
+        return False
+    if value != value.strip():
+        return False
+    return not looks_like_sentinel(value)
+
+
+def encode_header_value(value: str) -> str:
+    """Encode a value for transport, applying the base64 sentinel when needed.
+
+    Args:
+        value: Value to place in an HTTP header.
+
+    Returns:
+        The value verbatim when it is safe plain ASCII, otherwise
+        ``=?base64?{Base64EncodedValue}?=``.
+    """
+    if is_safe_plain_ascii(value):
+        return value
+    encoded = base64.b64encode(value.encode("utf-8")).decode("ascii")
+    return f"{SENTINEL_PREFIX}{encoded}{SENTINEL_SUFFIX}"
+
+
+def decode_header_value(value: str) -> str:
+    """Decode a header value, unwrapping the base64 sentinel when present.
+
+    Decoding is lenient: a malformed sentinel payload is logged and returned
+    verbatim so a bad header degrades into an ordinary comparison mismatch
+    rather than raising out of the request path.
+
+    Args:
+        value: Raw header value as received on the wire.
+
+    Returns:
+        The decoded value, or the input unchanged when it is not an encoded
+        sentinel (or the payload cannot be decoded).
+    """
+    if not looks_like_sentinel(value):
+        return value
+
+    payload = value[len(SENTINEL_PREFIX):-len(SENTINEL_SUFFIX)]
+    try:
+        return base64.b64decode(payload, validate=True).decode("utf-8")
+    except (binascii.Error, ValueError, UnicodeDecodeError) as e:
+        logger.warning(
+            "Malformed base64 sentinel in header value; using raw value",
+            error=str(e),
+            error_type=type(e).__name__,
+        )
+        return value
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class HeaderAnnotation:
+    """A validated ``x-mcp-header`` annotation found on an input-schema property.
+
+    Attributes:
+        token: The annotation value, i.e. the ``{Name}`` of ``Mcp-Param-{Name}``.
+        path: Property path from the schema root, e.g. ``("filters", "region")``.
+        type_name: Declared JSON Schema type of the annotated property.
+    """
+
+    token: str
+    path: Tuple[str, ...]
+    type_name: str
+
+    @property
+    def header_name(self) -> str:
+        """Full HTTP header name for this annotation."""
+        return f"{PARAM_HEADER_PREFIX}{self.token}"
+
+
+@dataclass(frozen=True)
+class SchemaAnnotationError:
+    """A problem found while validating ``x-mcp-header`` annotations.
+
+    Attributes:
+        code: Short machine-readable reason, e.g. ``"invalid_token"``.
+        message: Human-readable explanation.
+        path: Property path of the offending node (empty tuple for the root).
+        token: The offending annotation value, when it is a string.
+    """
+
+    code: str
+    message: str
+    path: Tuple[str, ...] = ()
+    token: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Render the error as a JSON-serialisable dictionary."""
+        return {
+            "code": self.code,
+            "message": self.message,
+            "path": list(self.path),
+            "token": self.token,
+        }
+
+
+@dataclass(frozen=True)
+class HeaderValidationError:
+    """A single ``HeaderMismatch`` finding.
+
+    Attributes:
+        header: The HTTP header name involved.
+        message: Human-readable explanation.
+        reason: Short machine-readable reason.
+        header_value: Decoded header value, when one was supplied.
+        body_value: The value found in the request body, when one was present.
+    """
+
+    header: str
+    message: str
+    reason: str
+    header_value: Optional[str] = None
+    body_value: Any = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Render the error as a JSON-serialisable dictionary."""
+        return {
+            "header": self.header,
+            "message": self.message,
+            "reason": self.reason,
+            "headerValue": self.header_value,
+            "bodyValue": self.body_value,
+        }
+
+
+# ---------------------------------------------------------------------------
+# (C) x-mcp-header inputSchema validation
+# ---------------------------------------------------------------------------
+
+def _iter_reachable_properties(
+    schema: Any,
+    prefix: Tuple[str, ...] = (),
+    seen: Optional[set] = None,
+):
+    """Yield ``(path, subschema)`` for properties reachable via ``properties`` chains.
+
+    Descent happens through the ``properties`` keyword only. ``items``,
+    ``oneOf``/``anyOf``/``allOf``/``not``, ``if``/``then``/``else`` and ``$ref``
+    are deliberately never followed, so anything nested under them is not
+    statically reachable.
+    """
+    if seen is None:
+        seen = set()
+    if not isinstance(schema, dict) or id(schema) in seen:
+        return
+    seen.add(id(schema))
+
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        return
+
+    for name, subschema in properties.items():
+        if not isinstance(name, str) or not isinstance(subschema, dict):
+            continue
+        path = prefix + (name,)
+        yield path, subschema
+        yield from _iter_reachable_properties(subschema, path, seen)
+
+
+def _iter_all_dicts(node: Any, seen: Optional[set] = None):
+    """Yield every dictionary anywhere in a JSON-Schema-shaped structure."""
+    if seen is None:
+        seen = set()
+    if isinstance(node, dict):
+        if id(node) in seen:
+            return
+        seen.add(id(node))
+        yield node
+        for value in node.values():
+            yield from _iter_all_dicts(value, seen)
+    elif isinstance(node, list):
+        if id(node) in seen:
+            return
+        seen.add(id(node))
+        for item in node:
+            yield from _iter_all_dicts(item, seen)
+
+
+def _validate_token(token: Any, path: Tuple[str, ...]) -> Optional[SchemaAnnotationError]:
+    """Check one annotation value against the syntactic constraints."""
+    if not isinstance(token, str):
+        return SchemaAnnotationError(
+            code="not_a_string",
+            message=f"{ANNOTATION_KEY} must be a string, got {type(token).__name__}",
+            path=path,
+        )
+    if token == "":
+        return SchemaAnnotationError(
+            code="empty",
+            message=f"{ANNOTATION_KEY} must not be empty",
+            path=path,
+            token=token,
+        )
+    if "\r" in token or "\n" in token:
+        return SchemaAnnotationError(
+            code="crlf",
+            message=f"{ANNOTATION_KEY} must not contain CR or LF",
+            path=path,
+            token=token,
+        )
+    if not _TOKEN_RE.match(token):
+        return SchemaAnnotationError(
+            code="invalid_token",
+            message=f"{ANNOTATION_KEY} must be an RFC 9110 tchar token",
+            path=path,
+            token=token,
+        )
+    return None
+
+
+def _collect_annotations(
+    input_schema: Any,
+) -> Tuple[List[HeaderAnnotation], List[SchemaAnnotationError]]:
+    """Collect valid annotations and every constraint violation in one pass."""
+    annotations: List[HeaderAnnotation] = []
+    errors: List[SchemaAnnotationError] = []
+
+    if not isinstance(input_schema, dict):
+        return annotations, errors
+
+    reachable: Dict[int, Tuple[str, ...]] = {}
+    ordered: List[Tuple[Tuple[str, ...], Dict[str, Any]]] = []
+    for path, subschema in _iter_reachable_properties(input_schema):
+        reachable[id(subschema)] = path
+        ordered.append((path, subschema))
+
+    seen_tokens: Dict[str, Tuple[str, ...]] = {}
+
+    for path, subschema in ordered:
+        if ANNOTATION_KEY not in subschema:
+            continue
+        token = subschema[ANNOTATION_KEY]
+
+        token_error = _validate_token(token, path)
+        if token_error is not None:
+            errors.append(token_error)
+            continue
+
+        type_name = subschema.get("type")
+        if type_name not in ALLOWED_ANNOTATION_TYPES:
+            errors.append(SchemaAnnotationError(
+                code="invalid_type",
+                message=(
+                    f"{ANNOTATION_KEY} requires a primitive type "
+                    f"({', '.join(ALLOWED_ANNOTATION_TYPES)}), got {type_name!r}"
+                ),
+                path=path,
+                token=token,
+            ))
+            continue
+
+        lowered = token.lower()
+        if lowered in seen_tokens:
+            errors.append(SchemaAnnotationError(
+                code="duplicate",
+                message=(
+                    f"{ANNOTATION_KEY} {token!r} duplicates the annotation at "
+                    f"{'.'.join(seen_tokens[lowered]) or '<root>'} "
+                    "(names are compared case-insensitively)"
+                ),
+                path=path,
+                token=token,
+            ))
+            continue
+        seen_tokens[lowered] = path
+
+        annotations.append(HeaderAnnotation(token=token, path=path, type_name=type_name))
+
+    # Anything carrying the annotation that is not a statically reachable
+    # property is rejected: nested in items/combinators/conditionals/$defs, or
+    # sitting on the schema root (which is not a property at all).
+    for node in _iter_all_dicts(input_schema):
+        if ANNOTATION_KEY not in node or id(node) in reachable:
+            continue
+        token = node[ANNOTATION_KEY]
+        if node is input_schema:
+            errors.append(SchemaAnnotationError(
+                code="not_a_property",
+                message=f"{ANNOTATION_KEY} may only annotate a property, not the schema root",
+                path=(),
+                token=token if isinstance(token, str) else None,
+            ))
+        else:
+            errors.append(SchemaAnnotationError(
+                code="unreachable",
+                message=(
+                    f"{ANNOTATION_KEY} is not statically reachable from the schema "
+                    "root through 'properties' chains"
+                ),
+                path=(),
+                token=token if isinstance(token, str) else None,
+            ))
+
+    return annotations, errors
+
+
+def validate_header_annotations(input_schema: Any) -> List[SchemaAnnotationError]:
+    """Validate every ``x-mcp-header`` annotation in a tool input schema.
+
+    Enforced constraints: the annotation value must be a non-empty RFC 9110
+    ``tchar`` token containing no CR/LF, must be unique within the schema when
+    compared case-insensitively, must sit on a property whose type is one of
+    ``integer``/``string``/``boolean`` (``number`` is not permitted), and must be
+    statically reachable from the schema root through ``properties`` chains only.
+
+    Args:
+        input_schema: The tool's JSON Schema ``inputSchema``.
+
+    Returns:
+        A list of :class:`SchemaAnnotationError`; empty when the schema is valid.
+    """
+    return _collect_annotations(input_schema)[1]
+
+
+def collect_header_annotations(input_schema: Any) -> List[HeaderAnnotation]:
+    """Collect the annotations of a tool input schema that pass validation.
+
+    Args:
+        input_schema: The tool's JSON Schema ``inputSchema``.
+
+    Returns:
+        A list of valid :class:`HeaderAnnotation`, in schema order. Invalid
+        annotations are omitted; use :func:`validate_header_annotations` to see
+        why.
+    """
+    return _collect_annotations(input_schema)[0]
+
+
+# ---------------------------------------------------------------------------
+# Value formatting and comparison
+# ---------------------------------------------------------------------------
+
+_MISSING = object()
+
+
+def _lookup_path(container: Any, path: Sequence[str]) -> Any:
+    """Return the value at an exact property path, or ``_MISSING``."""
+    current = container
+    for key in path:
+        if not isinstance(current, Mapping) or key not in current:
+            return _MISSING
+        current = current[key]
+    return current
+
+
+def _format_header_value(value: Any) -> str:
+    """Render a primitive body value the way it appears in a header."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    return str(value)
+
+
+def _parse_number(value: Any) -> Optional[float]:
+    """Coerce a value to a float for numeric comparison, or return None.
+
+    Strings are accepted only when they match the JSON number grammar. Python's
+    own ``float()`` is far more permissive -- it accepts PEP 515 underscore
+    separators (``"4_2"``), Unicode decimal digits (``"４２"``), ``"inf"`` and
+    ``"nan"`` -- none of which a client could legitimately have produced from a
+    JSON number, so accepting them would let a header that does not encode the
+    body value pass validation.
+
+    Args:
+        value: Header string or body value to coerce.
+
+    Returns:
+        The numeric value, or None when it is not a number.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        if not _JSON_NUMBER_RE.match(value):
+            return None
+        try:
+            return float(value)
+        except ValueError:  # pragma: no cover - the grammar already guarantees this parses
+            return None
+    return None
+
+
+def _normalize_uri(value: Any) -> Any:
+    """Normalise a URI so equivalent spellings compare equal.
+
+    A client that mirrors ``params.uri`` into ``Mcp-Name`` sends the bytes it put
+    in the body, but any intermediary that round-trips the URI through a parser
+    may hand back a normalised form (lowercased scheme and host, an explicit
+    ``/`` path for a bare authority). Both sides are normalised the same way so
+    such a round trip is not reported as a mismatch.
+
+    Args:
+        value: Candidate URI. Non-strings are returned unchanged.
+
+    Returns:
+        The normalised URI, or the input unchanged when it cannot be parsed.
+    """
+    if not isinstance(value, str):
+        return value
+    try:
+        parts = urlsplit(value)
+    except ValueError:
+        return value
+    if not parts.scheme:
+        return value
+    path = parts.path
+    if parts.netloc and not path:
+        path = "/"
+    return urlunsplit((parts.scheme.lower(), parts.netloc.lower(), path, parts.query, parts.fragment))
+
+
+def _values_match(header_value: str, body_value: Any, type_name: Optional[str] = None) -> bool:
+    """Compare a decoded header value against a body value.
+
+    Header values are case-sensitive. Integer parameters compare numerically, so
+    a header of ``"42.0"`` matches a body value of ``42``. ``uri`` is a
+    pseudo-type used internally for the ``Mcp-Name``/``params.uri`` pairing and
+    compares after URI normalisation.
+
+    Args:
+        header_value: Decoded header value.
+        body_value: Value taken from the request body.
+        type_name: Declared JSON Schema type of the parameter, when known.
+
+    Returns:
+        True when the two represent the same value.
+    """
+    if isinstance(body_value, bool):
+        return header_value == _format_header_value(body_value)
+
+    if type_name == "uri":
+        return _normalize_uri(header_value) == _normalize_uri(body_value)
+
+    # "number" is not a permitted annotation type, so an integer annotation is
+    # the only declared type that reaches the numeric branch; a numeric body
+    # value gets there on its own regardless of what was declared.
+    if type_name == "integer" or isinstance(body_value, (int, float)):
+        left = _parse_number(header_value)
+        right = _parse_number(body_value)
+        if left is not None and right is not None:
+            return left == right
+
+    return header_value == _format_header_value(body_value)
+
+
+# ---------------------------------------------------------------------------
+# (C) Outgoing header extraction
+# ---------------------------------------------------------------------------
+
+def extract_param_headers(
+    annotations: Sequence[HeaderAnnotation],
+    arguments: Any,
+) -> Dict[str, str]:
+    """Build the ``Mcp-Param-*`` headers for a set of tool arguments.
+
+    The value is read at the annotated property's exact path. When no value is
+    present there -- the path is missing, or the value is null -- the header is
+    omitted entirely, which is not an error.
+
+    Args:
+        annotations: Validated annotations, e.g. from
+            :func:`collect_header_annotations`.
+        arguments: The tool call arguments (``params.arguments``).
+
+    Returns:
+        Mapping of header name to encoded header value.
+    """
+    headers: Dict[str, str] = {}
+    for annotation in annotations:
+        value = _lookup_path(arguments, annotation.path)
+        if value is _MISSING or value is None:
+            continue
+        headers[annotation.header_name] = encode_header_value(_format_header_value(value))
+    return headers
+
+
+# ---------------------------------------------------------------------------
+# (B) Header / body validation
+# ---------------------------------------------------------------------------
+
+def strict_headers_enabled() -> bool:
+    """Read the ``PROMETHEUS_MCP_STRICT_HEADERS`` opt-in switch.
+
+    The environment is read at call time (not import time) so it can be changed
+    per test. Callers that carry their own configuration should pass ``strict``
+    explicitly instead of relying on this helper.
+
+    Returns:
+        True when strict header validation is switched on. Default is False.
+    """
+    return os.environ.get("PROMETHEUS_MCP_STRICT_HEADERS", "False").lower() in ("true", "1", "yes")
+
+
+def _normalize_headers(headers: Optional[Mapping[str, str]]) -> Dict[str, str]:
+    """Lowercase header names so lookups are case-insensitive."""
+    if not headers:
+        return {}
+    return {str(name).lower(): value for name, value in headers.items()}
+
+
+def _body_meta(body: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return the request ``_meta`` mapping, preferring the one inside params."""
+    params = body.get("params")
+    if isinstance(params, Mapping):
+        meta = params.get("_meta")
+        if isinstance(meta, Mapping):
+            return meta
+    meta = body.get("_meta")
+    return meta if isinstance(meta, Mapping) else {}
+
+
+def _check_scalar(
+    normalized: Mapping[str, str],
+    header: str,
+    body_value: Any,
+    type_name: Optional[str] = None,
+) -> Optional[HeaderValidationError]:
+    """Compare one header against one body value, honouring the absence rules.
+
+    The rule is asymmetric, which is the whole point: the ``Mcp-*`` headers are
+    optional routing hints, so an absent header is never an error, while a
+    header sent for a body value that does not exist cannot be a hint about
+    anything and is reported as ``unexpected_header``.
+    """
+    raw = normalized.get(header.lower())
+    present = raw is not None
+    has_body_value = body_value is not _MISSING and body_value is not None
+
+    if not has_body_value:
+        # Absent or null in the body: the header must be omitted, and its
+        # absence is explicitly not an error.
+        if present:
+            return HeaderValidationError(
+                header=header,
+                message=f"{header} was sent but the request body carries no corresponding value",
+                reason="unexpected_header",
+                header_value=decode_header_value(raw),
+            )
+        return None
+
+    if not present:
+        # A client is never obliged to send the hint. Treating this as a
+        # mismatch would make every Mcp-* header mandatory and lock out every
+        # client that predates 2026-07-28, including the initialize handshake.
+        return None
+
+    decoded = decode_header_value(raw)
+    if not _values_match(decoded, body_value, type_name):
+        return HeaderValidationError(
+            header=header,
+            message=f"{header} does not match the request body",
+            reason="mismatch",
+            header_value=decoded,
+            body_value=body_value,
+        )
+    return None
+
+
+def validate_request_headers(
+    headers: Optional[Mapping[str, str]],
+    body: Optional[Mapping[str, Any]],
+    strict: bool = False,
+    header_annotations: Optional[Sequence[HeaderAnnotation]] = None,
+) -> List[HeaderValidationError]:
+    """Validate the ``Mcp-*`` headers of a request against its JSON-RPC body.
+
+    Checks ``Mcp-Method`` against ``method``, ``Mcp-Name`` against
+    ``params.name`` (falling back to ``params.uri``), and one
+    ``Mcp-Param-{Name}`` header per supplied annotation against the argument at
+    that annotation's path.
+
+    Header names are matched case-insensitively; header values are compared
+    case-sensitively after base64-sentinel decoding. Integer parameters compare
+    numerically, and a ``params.uri`` is compared after URI normalisation. Both
+    absence rules are honoured: a header must be omitted when the corresponding
+    body value is absent or null, and an omitted header is never an error
+    because the ``Mcp-*`` headers are optional hints rather than requirements.
+
+    ``MCP-Protocol-Version`` is only compared when the request body declares a
+    protocol version *other than* 2026-07-28. It is a transport header the
+    Streamable-HTTP spec requires on every post-initialize request, so it is
+    routinely present with nothing in ``_meta`` to mirror (a 2025-11-25 client),
+    and a 2026-07-28 client cannot put its own revision in it at all: the SDK
+    transport rejects an unknown value with -32600 before the request is parsed,
+    which forces the header to carry the transport-negotiated revision while
+    ``_meta`` carries 2026-07-28. Comparing those two would reject every client
+    that exists. Any other declared revision *is* one the transport can carry,
+    so the comparison stays meaningful there.
+
+    Args:
+        headers: Incoming HTTP headers (any case-insensitive or plain mapping).
+        body: The parsed JSON-RPC request body.
+        strict: Opt-in switch. When False (the default) this function is a
+            no-op, so 2025-11-25 clients that send no ``Mcp-*`` headers are
+            unaffected.
+        header_annotations: Validated ``x-mcp-header`` annotations for the tool
+            being called, used to check the ``Mcp-Param-*`` headers.
+
+    Returns:
+        A list of :class:`HeaderValidationError`; empty when the request is
+        consistent (or when ``strict`` is False).
+    """
+    if not strict:
+        return []
+
+    if not isinstance(body, Mapping):
+        return []
+
+    normalized = _normalize_headers(headers)
+    errors: List[HeaderValidationError] = []
+
+    method = body.get("method", _MISSING)
+    error = _check_scalar(normalized, HEADER_MCP_METHOD, method)
+    if error is not None:
+        errors.append(error)
+
+    params = body.get("params")
+    params_mapping: Mapping[str, Any] = params if isinstance(params, Mapping) else {}
+
+    name_value = params_mapping.get("name", _MISSING)
+    name_type: Optional[str] = None
+    if name_value is _MISSING or name_value is None:
+        name_value = params_mapping.get("uri", _MISSING)
+        name_type = "uri"
+    error = _check_scalar(normalized, HEADER_MCP_NAME, name_value, type_name=name_type)
+    if error is not None:
+        errors.append(error)
+
+    protocol_version = _body_meta(body).get(META_PROTOCOL_VERSION, _MISSING)
+    if (
+        protocol_version is not _MISSING
+        and protocol_version is not None
+        and protocol_version != PROTOCOL_VERSION_2026
+    ):
+        error = _check_scalar(normalized, HEADER_MCP_PROTOCOL_VERSION, protocol_version)
+        if error is not None:
+            errors.append(error)
+
+    arguments = params_mapping.get("arguments")
+    for annotation in header_annotations or ():
+        value = _lookup_path(arguments, annotation.path)
+        error = _check_scalar(
+            normalized,
+            annotation.header_name,
+            value,
+            type_name=annotation.type_name,
+        )
+        if error is not None:
+            errors.append(error)
+
+    if errors:
+        logger.warning(
+            "Header validation failed",
+            method=method if method is not _MISSING else None,
+            mismatch_count=len(errors),
+            mismatched_headers=[error.header for error in errors],
+        )
+
+    return errors
+
+
+def header_mismatch_error(errors: Sequence[HeaderValidationError]) -> Dict[str, Any]:
+    """Render header validation findings as a JSON-RPC error object.
+
+    Args:
+        errors: Findings from :func:`validate_request_headers`.
+
+    Returns:
+        A JSON-RPC error dictionary with code ``-32020`` (HeaderMismatch) and a
+        ``data.mismatches`` list describing each finding.
+    """
+    return {
+        "code": HEADER_MISMATCH,
+        "message": "HeaderMismatch: HTTP headers do not match the request body",
+        "data": {"mismatches": [error.to_dict() for error in errors]},
+    }

--- a/src/prometheus_mcp_server/spec2026/negotiation.py
+++ b/src/prometheus_mcp_server/spec2026/negotiation.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python
+
+"""Per-request protocol negotiation for the MCP 2026-07-28 compatibility layer.
+
+Under 2026-07-28 the client restates who it is and what it can do on *every*
+request, inside ``params._meta``, instead of once during ``initialize``. The
+specification is explicit that a server MUST NOT infer a client's capabilities
+from an earlier request, so this module deliberately offers no cache: state is
+extracted per request, published on a :class:`contextvars.ContextVar` for the
+duration of that request, and reset afterwards.
+
+Backward compatibility is preserved by treating a missing
+``io.modelcontextprotocol/protocolVersion`` as "legacy client" rather than as an
+error. Only a version that is *present and unrecognised* is rejected, with
+JSON-RPC code ``-32022``.
+
+Nothing here introspects SDK internals, and every conversion of a foreign object
+into a mapping is defensive, so a future ``mcp`` release cannot break import or
+raise from the extraction path.
+"""
+
+import contextvars
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterator, Optional
+
+from prometheus_mcp_server.logging_config import get_logger
+from prometheus_mcp_server.spec2026.constants import (
+    META_CLIENT_CAPABILITIES,
+    META_CLIENT_INFO,
+    META_LOG_LEVEL,
+    META_PROTOCOL_VERSION,
+    SUPPORTED_PROTOCOL_VERSIONS,
+    UNSUPPORTED_PROTOCOL_VERSION,
+)
+
+logger = get_logger()
+
+
+class NegotiationError(Exception):
+    """A request cannot be served because its ``_meta`` failed negotiation.
+
+    Carries the JSON-RPC ``code``/``message``/``data`` triple so callers can
+    turn it into an error response without re-deriving any of it.
+    """
+
+    def __init__(self, code: int, message: str, data: Optional[Dict[str, Any]] = None) -> None:
+        """Initialise the error.
+
+        Args:
+            code: JSON-RPC error code to report.
+            message: Concise single-sentence description of the failure.
+            data: Optional structured payload for the ``error.data`` member.
+        """
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.data = data
+
+    def to_error_data(self) -> Dict[str, Any]:
+        """Render the error as a JSON-RPC ``error`` object.
+
+        Returns:
+            Dictionary with ``code``, ``message`` and ``data`` members.
+        """
+        return {"code": self.code, "message": self.message, "data": self.data}
+
+    def to_mcp_error(self) -> Exception:
+        """Convert to the SDK's ``McpError`` so a handler can raise it directly.
+
+        The low-level server turns a raised ``McpError`` into the exact
+        JSON-RPC error carried here. The SDK import is done lazily and
+        defensively so that an incompatible SDK degrades to returning ``self``
+        rather than raising an unrelated exception.
+
+        Returns:
+            An ``mcp.shared.exceptions.McpError`` when the SDK exposes one,
+            otherwise this exception itself.
+        """
+        try:
+            from mcp.shared.exceptions import McpError
+            from mcp.types import ErrorData
+
+            return McpError(ErrorData(code=self.code, message=self.message, data=self.data))
+        except Exception as e:  # pragma: no cover - depends on SDK layout
+            logger.warning(
+                "Could not build McpError from negotiation failure; returning raw error",
+                error=str(e),
+                error_type=type(e).__name__,
+            )
+            return self
+
+
+class UnsupportedProtocolVersionError(NegotiationError):
+    """The request named a protocol version this server does not speak."""
+
+    def __init__(self, requested: Any) -> None:
+        """Initialise the error for a rejected protocol version.
+
+        Args:
+            requested: The unusable value read from
+                ``_meta["io.modelcontextprotocol/protocolVersion"]``. Non-string
+                values are stringified so the payload stays JSON-serialisable.
+        """
+        readable = requested if isinstance(requested, str) else str(requested)
+        super().__init__(
+            code=UNSUPPORTED_PROTOCOL_VERSION,
+            message=f"Unsupported protocol version: {readable}",
+            data={
+                "supported": list(SUPPORTED_PROTOCOL_VERSIONS),
+                "requested": readable,
+            },
+        )
+        self.requested = readable
+
+
+@dataclass(frozen=True)
+class RequestNegotiation:
+    """Negotiation state extracted from a single request's ``_meta``.
+
+    Attributes:
+        protocol_version: Version the client declared, or ``None`` for a legacy
+            client that declared none.
+        client_capabilities: Capabilities declared on *this* request only.
+        client_info: Client implementation name/version for this request.
+        log_level: Requested minimum log severity, or ``None`` when the client
+            did not opt into ``notifications/message`` for this request.
+        meta: The raw ``_meta`` mapping, so downstream modules (trace-context
+            propagation, header validation) can read keys this class does not
+            model.
+    """
+
+    protocol_version: Optional[str] = None
+    client_capabilities: Dict[str, Any] = field(default_factory=dict)
+    client_info: Dict[str, Any] = field(default_factory=dict)
+    log_level: Optional[str] = None
+    meta: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def is_legacy(self) -> bool:
+        """Whether the client declared no protocol version on this request.
+
+        Returns:
+            True when no ``io.modelcontextprotocol/protocolVersion`` was sent.
+        """
+        return self.protocol_version is None
+
+    @property
+    def may_log(self) -> bool:
+        """Whether ``notifications/message`` may be emitted for this request.
+
+        Returns:
+            True only when the request carried a log level.
+        """
+        return self.log_level is not None
+
+
+#: Per-request negotiation state. Defaults to ``None`` so that code running
+#: outside a negotiated request sees "nothing declared" rather than stale data
+#: from a previous request.
+_CURRENT_NEGOTIATION: contextvars.ContextVar[Optional[RequestNegotiation]] = contextvars.ContextVar(
+    "prometheus_mcp_spec2026_negotiation",
+    default=None,
+)
+
+
+def _get_field(source: Any, name: str) -> Any:
+    """Read ``name`` from an object attribute or a mapping key, else ``None``."""
+    if isinstance(source, dict):
+        return source.get(name)
+    return getattr(source, name, None)
+
+
+def _coerce_mapping(value: Any) -> Optional[Dict[str, Any]]:
+    """Best-effort conversion of an arbitrary value into a plain dict.
+
+    Handles plain dicts, pydantic models (``model_dump`` then ``model_extra``)
+    and anything else by returning ``None``.
+
+    Args:
+        value: Candidate mapping-like object.
+
+    Returns:
+        A new dict, or ``None`` when the value is not mapping-like.
+    """
+    if value is None:
+        return None
+
+    if isinstance(value, dict):
+        return dict(value)
+
+    dump = getattr(value, "model_dump", None)
+    if callable(dump):
+        try:
+            dumped = dump(by_alias=True, exclude_none=True)
+        except Exception as e:
+            logger.warning(
+                "Could not dump request metadata model",
+                error=str(e),
+                error_type=type(e).__name__,
+                value_type=type(value).__name__,
+            )
+        else:
+            if isinstance(dumped, dict):
+                return dumped
+
+    extra = getattr(value, "model_extra", None)
+    if isinstance(extra, dict):
+        return dict(extra)
+
+    return None
+
+
+def extract_request_meta(request: Any) -> Dict[str, Any]:
+    """Pull the ``_meta`` mapping off an incoming request.
+
+    Accepts a parsed MCP request model, a raw JSON-RPC request dict, a bare
+    params object/dict, or anything exposing ``meta``/``_meta``. Every failure
+    mode the specification permits -- ``_meta`` absent, explicitly ``None``, or
+    present but not an object -- yields an empty dict rather than an exception.
+
+    Args:
+        request: The request, params, or metadata container to inspect.
+
+    Returns:
+        The ``_meta`` mapping with string keys, or an empty dict.
+    """
+    if request is None:
+        return {}
+
+    params = _get_field(request, "params")
+    source = request if params is None else params
+
+    raw_meta = _get_field(source, "meta")
+    if raw_meta is None:
+        raw_meta = _get_field(source, "_meta")
+
+    if raw_meta is None:
+        return {}
+
+    coerced = _coerce_mapping(raw_meta)
+    if coerced is None:
+        logger.warning(
+            "Ignoring malformed request _meta",
+            meta_type=type(raw_meta).__name__,
+        )
+        return {}
+
+    return {str(key): value for key, value in coerced.items()}
+
+
+def validate_protocol_version(version: Any) -> Optional[str]:
+    """Validate a declared protocol version.
+
+    A missing version is legal: pre-2026 clients never send one and must keep
+    working unchanged.
+
+    Args:
+        version: Raw value read from ``_meta``, or ``None`` when absent.
+
+    Returns:
+        The accepted version string, or ``None`` when none was declared.
+
+    Raises:
+        UnsupportedProtocolVersionError: The value was present but is not one of
+            ``SUPPORTED_PROTOCOL_VERSIONS``. Carries JSON-RPC code ``-32022``
+            and ``data={"supported": [...], "requested": "..."}``.
+    """
+    if version is None:
+        return None
+
+    if isinstance(version, str) and version in SUPPORTED_PROTOCOL_VERSIONS:
+        return version
+
+    logger.warning(
+        "Rejecting unsupported protocol version",
+        requested=version if isinstance(version, str) else str(version),
+        supported=list(SUPPORTED_PROTOCOL_VERSIONS),
+    )
+    raise UnsupportedProtocolVersionError(version)
+
+
+def _extract_log_level(meta: Dict[str, Any]) -> Optional[str]:
+    """Read the requested log level, treating any non-string value as absent."""
+    raw_level = meta.get(META_LOG_LEVEL)
+    if raw_level is None:
+        return None
+
+    if isinstance(raw_level, str) and raw_level.strip():
+        return raw_level
+
+    logger.warning(
+        "Ignoring malformed log level in request _meta; log notifications stay disabled",
+        log_level_type=type(raw_level).__name__,
+    )
+    return None
+
+
+def _extract_mapping(meta: Dict[str, Any], key: str) -> Dict[str, Any]:
+    """Read a mapping-valued ``_meta`` key, defaulting to an empty dict."""
+    raw_value = meta.get(key)
+    if raw_value is None:
+        return {}
+
+    coerced = _coerce_mapping(raw_value)
+    if coerced is None:
+        logger.warning(
+            "Ignoring malformed request _meta entry",
+            meta_key=key,
+            value_type=type(raw_value).__name__,
+        )
+        return {}
+
+    return coerced
+
+
+def negotiation_from_meta(meta: Any) -> RequestNegotiation:
+    """Build negotiation state from an already-extracted ``_meta`` mapping.
+
+    Args:
+        meta: The ``_meta`` mapping. Anything that is not a dict (including
+            ``None``) is treated as an empty mapping.
+
+    Returns:
+        The negotiation state for this request.
+
+    Raises:
+        UnsupportedProtocolVersionError: A protocol version was declared but is
+            not supported.
+    """
+    if not isinstance(meta, dict):
+        if meta is not None:
+            logger.warning(
+                "Ignoring malformed request _meta",
+                meta_type=type(meta).__name__,
+            )
+        meta = {}
+
+    protocol_version = validate_protocol_version(meta.get(META_PROTOCOL_VERSION))
+
+    return RequestNegotiation(
+        protocol_version=protocol_version,
+        client_capabilities=_extract_mapping(meta, META_CLIENT_CAPABILITIES),
+        client_info=_extract_mapping(meta, META_CLIENT_INFO),
+        log_level=_extract_log_level(meta),
+        meta=dict(meta),
+    )
+
+
+def negotiate_request(request: Any) -> RequestNegotiation:
+    """Extract and validate the negotiation state of an incoming request.
+
+    Args:
+        request: The request, params, or metadata container to inspect.
+
+    Returns:
+        The negotiation state for this request.
+
+    Raises:
+        UnsupportedProtocolVersionError: A protocol version was declared but is
+            not supported.
+    """
+    return negotiation_from_meta(extract_request_meta(request))
+
+
+def get_current_negotiation() -> Optional[RequestNegotiation]:
+    """Return the negotiation state of the request being served.
+
+    Returns:
+        The current state, or ``None`` when no request is in scope. ``None`` is
+        never a stale value from an earlier request: capabilities are
+        per-request and are always reset.
+    """
+    return _CURRENT_NEGOTIATION.get()
+
+
+def set_current_negotiation(negotiation: Optional[RequestNegotiation]) -> contextvars.Token:
+    """Publish negotiation state for the request being served.
+
+    Args:
+        negotiation: State to publish, or ``None`` to explicitly declare that
+            nothing was negotiated.
+
+    Returns:
+        A token that must be handed to :func:`reset_current_negotiation` once
+        the request completes.
+    """
+    return _CURRENT_NEGOTIATION.set(negotiation)
+
+
+def reset_current_negotiation(token: Optional[contextvars.Token]) -> None:
+    """Restore the negotiation state that preceded ``token``.
+
+    Called from a ``finally`` block, this is what stops one request's declared
+    capabilities from leaking into the next. A token created in a different
+    context (which ``ContextVar.reset`` rejects) still results in the variable
+    being cleared, so a leak is impossible even on the error path.
+
+    Args:
+        token: Token returned by :func:`set_current_negotiation`, or ``None``
+            when no state was published.
+    """
+    if token is None:
+        _CURRENT_NEGOTIATION.set(None)
+        return
+
+    try:
+        _CURRENT_NEGOTIATION.reset(token)
+    except (ValueError, RuntimeError) as e:
+        logger.warning(
+            "Could not reset negotiation context with token; clearing instead",
+            error=str(e),
+            error_type=type(e).__name__,
+        )
+        _CURRENT_NEGOTIATION.set(None)
+
+
+def clear_current_negotiation() -> None:
+    """Drop any published negotiation state.
+
+    Use when no token is available, for instance when tearing down a context
+    that was populated by code outside this module.
+    """
+    _CURRENT_NEGOTIATION.set(None)
+
+
+@contextmanager
+def negotiation_scope(negotiation: Optional[RequestNegotiation]) -> Iterator[Optional[RequestNegotiation]]:
+    """Publish negotiation state for the duration of a ``with`` block.
+
+    The state is always reset on exit, including when the body raises, which is
+    the leak-proof way to satisfy the specification's requirement that
+    capabilities never carry across requests.
+
+    Args:
+        negotiation: State to publish for the duration of the block.
+
+    Yields:
+        The same state that was published.
+    """
+    token = set_current_negotiation(negotiation)
+    try:
+        yield negotiation
+    finally:
+        reset_current_negotiation(token)
+
+
+def may_emit_log_notifications(negotiation: Optional[RequestNegotiation] = None) -> bool:
+    """Whether ``notifications/message`` may be emitted for a request.
+
+    Under 2026-07-28 a server MUST NOT send log notifications unless the request
+    carried ``io.modelcontextprotocol/logLevel``, so the answer defaults to
+    ``False`` whenever nothing was negotiated.
+
+    Args:
+        negotiation: State to consult. Defaults to the state of the request
+            currently in scope.
+
+    Returns:
+        True only when the request declared a log level.
+    """
+    state = negotiation if negotiation is not None else get_current_negotiation()
+    if state is None:
+        return False
+    return state.log_level is not None
+
+
+def current_log_level() -> Optional[str]:
+    """Return the log level declared by the request being served.
+
+    Returns:
+        The declared level, or ``None`` when none was declared (in which case
+        no log notifications may be emitted).
+    """
+    state = get_current_negotiation()
+    if state is None:
+        return None
+    return state.log_level
+
+
+__all__ = [
+    "NegotiationError",
+    "RequestNegotiation",
+    "UnsupportedProtocolVersionError",
+    "clear_current_negotiation",
+    "current_log_level",
+    "extract_request_meta",
+    "get_current_negotiation",
+    "may_emit_log_notifications",
+    "negotiate_request",
+    "negotiation_from_meta",
+    "negotiation_scope",
+    "reset_current_negotiation",
+    "set_current_negotiation",
+    "validate_protocol_version",
+]

--- a/src/prometheus_mcp_server/spec2026/otel.py
+++ b/src/prometheus_mcp_server/spec2026/otel.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python
+
+"""OpenTelemetry trace-context propagation (MCP 2026-07-28, feature F7).
+
+The 2026-07-28 specification allows a request's ``_meta`` object to carry W3C
+Trace Context fields (``traceparent``, ``tracestate``) and a W3C Baggage field
+(``baggage``). This module reads those values off an incoming request, validates
+them, and exposes them as outbound HTTP headers so they can be merged into the
+request the server makes against Prometheus.
+
+Security posture: a value that fails validation is *dropped*, never forwarded.
+Every candidate is checked against a printable-ASCII allowlist before anything
+else, so a hostile ``_meta`` payload cannot smuggle CR/LF into the outbound
+request and inject extra HTTP headers.
+
+Standard library only - this module intentionally has no dependency on any
+OpenTelemetry package, nor on the MCP SDK internals.
+"""
+
+import re
+from collections.abc import Mapping
+from contextlib import contextmanager
+from contextvars import ContextVar, Token
+from typing import Any, Dict, Iterator, Optional
+
+from prometheus_mcp_server.logging_config import get_logger
+
+logger = get_logger()
+
+# Header / _meta key names. The spec uses the lowercase W3C names verbatim.
+TRACEPARENT_HEADER = "traceparent"
+TRACESTATE_HEADER = "tracestate"
+BAGGAGE_HEADER = "baggage"
+
+TRACE_CONTEXT_KEYS = (TRACEPARENT_HEADER, TRACESTATE_HEADER, BAGGAGE_HEADER)
+
+# W3C Trace Context recommends implementations cap ``tracestate`` at 512 chars.
+MAX_TRACESTATE_LENGTH = 512
+# W3C Baggage caps the whole header at 8192 bytes.
+MAX_BAGGAGE_LENGTH = 8192
+
+# Values that are syntactically well formed but invalid per W3C.
+INVALID_VERSION = "ff"
+INVALID_TRACE_ID = "0" * 32
+INVALID_PARENT_ID = "0" * 16
+
+# version(2 hex) "-" trace-id(32 hex) "-" parent-id(16 hex) "-" flags(2 hex).
+# W3C mandates lowercase hex, so uppercase input is rejected rather than folded.
+_TRACEPARENT_RE = re.compile(r"[0-9a-f]{2}-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}")
+
+# Printable ASCII only. This excludes CR, LF, NUL, DEL, HTAB and every other
+# control character, plus all non-ASCII. HTAB is technically legal as optional
+# whitespace in the tracestate grammar, but it carries no meaning there and
+# rejecting it keeps the header-injection guard trivially auditable.
+_PRINTABLE_ASCII_RE = re.compile(r"[\x20-\x7e]*")
+
+# Per-request storage so make_prometheus_request can pick up the headers without
+# threading them through every tool signature.
+_TRACE_HEADERS: ContextVar[Optional[Dict[str, str]]] = ContextVar(
+    "prometheus_mcp_trace_headers", default=None
+)
+
+
+def is_safe_header_value(value: str) -> bool:
+    """Check that a string is safe to place in an HTTP header value.
+
+    Args:
+        value: Candidate header value.
+
+    Returns:
+        True when the value is printable ASCII only, i.e. contains no CR, LF or
+        any other control character. False otherwise.
+    """
+    return _PRINTABLE_ASCII_RE.fullmatch(value) is not None
+
+
+def validate_traceparent(value: Any) -> Optional[str]:
+    """Validate a W3C Trace Context ``traceparent`` value.
+
+    Enforces the ``version-traceid-parentid-flags`` layout and rejects the
+    reserved ``ff`` version, the all-zero trace-id and the all-zero parent-id,
+    all of which are invalid per W3C Trace Context.
+
+    Args:
+        value: Candidate value taken from a request's ``_meta``. Any type is
+            accepted; non-strings are rejected.
+
+    Returns:
+        The validated ``traceparent`` string, or None when the value is absent
+        or malformed and therefore must not be forwarded.
+    """
+    if not isinstance(value, str) or not value:
+        return None
+
+    if not is_safe_header_value(value):
+        logger.warning(
+            "Rejected traceparent with unsafe characters",
+            header=TRACEPARENT_HEADER,
+            reason="control_characters",
+        )
+        return None
+
+    if _TRACEPARENT_RE.fullmatch(value) is None:
+        logger.warning(
+            "Rejected malformed traceparent",
+            header=TRACEPARENT_HEADER,
+            reason="format",
+        )
+        return None
+
+    version, trace_id, parent_id, _flags = value.split("-")
+
+    if version == INVALID_VERSION:
+        logger.warning(
+            "Rejected traceparent with forbidden version",
+            header=TRACEPARENT_HEADER,
+            reason="forbidden_version",
+        )
+        return None
+
+    if trace_id == INVALID_TRACE_ID:
+        logger.warning(
+            "Rejected traceparent with all-zero trace id",
+            header=TRACEPARENT_HEADER,
+            reason="all_zero_trace_id",
+        )
+        return None
+
+    if parent_id == INVALID_PARENT_ID:
+        logger.warning(
+            "Rejected traceparent with all-zero parent id",
+            header=TRACEPARENT_HEADER,
+            reason="all_zero_parent_id",
+        )
+        return None
+
+    return value
+
+
+def _validate_list_header(value: Any, header: str, max_length: int) -> Optional[str]:
+    """Validate a comma-separated list-style trace header value.
+
+    Args:
+        value: Candidate value taken from a request's ``_meta``.
+        header: Header name, used for log context only.
+        max_length: Maximum permitted length of the trimmed value.
+
+    Returns:
+        The trimmed value, or None when it is absent, empty, too long or
+        contains characters that are unsafe in an HTTP header.
+    """
+    if not isinstance(value, str) or not value:
+        return None
+
+    if not is_safe_header_value(value):
+        logger.warning(
+            "Rejected trace header with unsafe characters",
+            header=header,
+            reason="control_characters",
+        )
+        return None
+
+    # Only spaces can survive the printable-ASCII check, and leading/trailing
+    # optional whitespace is insignificant in both grammars.
+    trimmed = value.strip()
+
+    if not trimmed:
+        logger.warning("Rejected empty trace header", header=header, reason="empty")
+        return None
+
+    if len(trimmed) > max_length:
+        logger.warning(
+            "Rejected oversized trace header",
+            header=header,
+            reason="too_long",
+            length=len(trimmed),
+            max_length=max_length,
+        )
+        return None
+
+    return trimmed
+
+
+def validate_tracestate(value: Any) -> Optional[str]:
+    """Validate a W3C Trace Context ``tracestate`` value.
+
+    Args:
+        value: Candidate value taken from a request's ``_meta``.
+
+    Returns:
+        The validated ``tracestate`` string, or None when it must be dropped.
+    """
+    return _validate_list_header(value, TRACESTATE_HEADER, MAX_TRACESTATE_LENGTH)
+
+
+def validate_baggage(value: Any) -> Optional[str]:
+    """Validate a W3C Baggage ``baggage`` value.
+
+    Args:
+        value: Candidate value taken from a request's ``_meta``.
+
+    Returns:
+        The validated ``baggage`` string, or None when it must be dropped.
+    """
+    return _validate_list_header(value, BAGGAGE_HEADER, MAX_BAGGAGE_LENGTH)
+
+
+def meta_as_mapping(meta: Any) -> Dict[str, Any]:
+    """Coerce a request ``_meta`` value into a plain dictionary.
+
+    Handles the three shapes this can arrive in: None, a plain mapping, or the
+    SDK's pydantic ``RequestParams.Meta`` model (which keeps spec extension keys
+    such as ``traceparent`` in ``model_extra`` because it is ``extra="allow"``).
+
+    Args:
+        meta: The request's ``_meta`` value.
+
+    Returns:
+        Dictionary of meta keys to values. Empty when nothing usable is present.
+    """
+    if meta is None:
+        return {}
+
+    if isinstance(meta, Mapping):
+        return dict(meta)
+
+    collected: Dict[str, Any] = {}
+
+    model_dump = getattr(meta, "model_dump", None)
+    if callable(model_dump):
+        dumped = model_dump()
+        if isinstance(dumped, Mapping):
+            collected.update(dumped)
+
+    # ``model_extra`` is authoritative for spec extension keys, so it wins.
+    model_extra = getattr(meta, "model_extra", None)
+    if isinstance(model_extra, Mapping):
+        collected.update(model_extra)
+
+    return collected
+
+
+def _lookup(data: Dict[str, Any], key: str) -> Any:
+    """Look up a lowercase key in a meta mapping, case-insensitively."""
+    if key in data:
+        return data[key]
+
+    for candidate_key, candidate_value in data.items():
+        if isinstance(candidate_key, str) and candidate_key.lower() == key:
+            return candidate_value
+
+    return None
+
+
+def extract_trace_headers(meta: Any) -> Dict[str, str]:
+    """Build outbound HTTP trace-context headers from a request's ``_meta``.
+
+    The returned mapping is intended to be merged into the headers of the
+    outbound Prometheus request. Callers decide precedence; merging these last
+    lets a caller-configured header win or lose as they prefer.
+
+    Args:
+        meta: The request's ``_meta`` value. May be None, a plain mapping, or
+            the SDK's pydantic ``RequestParams.Meta`` model.
+
+    Returns:
+        Mapping of HTTP header name to validated value. Empty when ``_meta`` is
+        absent or carries no forwardable trace context.
+    """
+    try:
+        data = meta_as_mapping(meta)
+        if not data:
+            return {}
+
+        headers: Dict[str, str] = {}
+
+        traceparent = validate_traceparent(_lookup(data, TRACEPARENT_HEADER))
+        if traceparent is not None:
+            headers[TRACEPARENT_HEADER] = traceparent
+
+            # W3C Trace Context: tracestate is meaningless without a valid
+            # traceparent and MUST NOT be propagated on its own.
+            tracestate = validate_tracestate(_lookup(data, TRACESTATE_HEADER))
+            if tracestate is not None:
+                headers[TRACESTATE_HEADER] = tracestate
+        elif _lookup(data, TRACESTATE_HEADER) is not None:
+            logger.warning(
+                "Dropping tracestate without a valid traceparent",
+                header=TRACESTATE_HEADER,
+                reason="no_traceparent",
+            )
+
+        # W3C Baggage is a separate propagation format and stands alone.
+        baggage = validate_baggage(_lookup(data, BAGGAGE_HEADER))
+        if baggage is not None:
+            headers[BAGGAGE_HEADER] = baggage
+
+        # Defence in depth: nothing leaves this function without a final
+        # header-injection check, even if a validator above is ever changed.
+        safe_headers = {
+            name: value
+            for name, value in headers.items()
+            if is_safe_header_value(value)
+        }
+        if len(safe_headers) != len(headers):
+            logger.warning(
+                "Dropped trace headers that failed the final injection guard",
+                dropped=sorted(set(headers) - set(safe_headers)),
+            )
+
+        return safe_headers
+
+    except Exception as e:
+        logger.warning(
+            "Failed to extract trace context from request _meta",
+            error=str(e),
+            error_type=type(e).__name__,
+        )
+        return {}
+
+
+def set_trace_headers(headers: Optional[Mapping]) -> Token:
+    """Stash trace-context headers for the current request context.
+
+    Args:
+        headers: Headers to stash, typically from ``extract_trace_headers``.
+            None or empty stashes an empty mapping.
+
+    Returns:
+        Token that restores the previous value when passed to
+        ``reset_trace_headers``.
+    """
+    snapshot: Dict[str, str] = dict(headers) if headers else {}
+    return _TRACE_HEADERS.set(snapshot)
+
+
+def get_trace_headers() -> Dict[str, str]:
+    """Get the trace-context headers stashed for the current context.
+
+    Returns:
+        Copy of the stashed headers, so callers cannot mutate the stored state.
+        Empty dictionary when nothing is stashed.
+    """
+    current = _TRACE_HEADERS.get()
+    return dict(current) if current else {}
+
+
+def reset_trace_headers(token: Token) -> None:
+    """Restore the trace-header context to its value before ``set_trace_headers``.
+
+    Args:
+        token: Token returned by ``set_trace_headers``.
+
+    Returns:
+        None. A stale or foreign token is logged and ignored rather than raised,
+        so a reset can never break request handling.
+    """
+    # CPython raises RuntimeError for an already-used token and ValueError for a
+    # token created in a different Context, so catch broadly rather than guess.
+    try:
+        _TRACE_HEADERS.reset(token)
+    except Exception as e:
+        logger.warning(
+            "Failed to reset trace header context",
+            error=str(e),
+            error_type=type(e).__name__,
+        )
+
+
+def clear_trace_headers() -> None:
+    """Drop any trace-context headers stashed for the current context.
+
+    Returns:
+        None.
+    """
+    _TRACE_HEADERS.set(None)
+
+
+@contextmanager
+def trace_context(meta: Any) -> Iterator[Dict[str, str]]:
+    """Extract trace headers from ``_meta`` and stash them for the block's scope.
+
+    Args:
+        meta: The request's ``_meta`` value.
+
+    Returns:
+        Context manager yielding the extracted headers. The previous context
+        value is always restored on exit, including on exception.
+    """
+    headers = extract_trace_headers(meta)
+    token = set_trace_headers(headers)
+    try:
+        yield headers
+    finally:
+        reset_trace_headers(token)

--- a/tests/test_spec2026_asgi.py
+++ b/tests/test_spec2026_asgi.py
@@ -1,0 +1,366 @@
+"""Tests for the ASGI-level strict ``Mcp-*`` header validation (F6).
+
+Header validation moved to the ASGI layer because it is the only place that
+sees the exact JSON-RPC body the client sent and the only place that still owns
+the HTTP status code. Every test here therefore drives a real ASGI app rather
+than a synthesized middleware context -- the class of test that was missing when
+strict mode shipped able to reject every client that exists.
+"""
+
+import json
+
+import httpx
+import pytest
+
+import prometheus_mcp_server.server as server
+from prometheus_mcp_server.spec2026.asgi import (
+    HEADER_MISMATCH_STATUS,
+    MAX_BUFFERED_BODY_BYTES,
+    StrictHeaderMiddleware,
+    strict_header_middleware,
+    tool_annotation_lookup,
+)
+from prometheus_mcp_server.server import mcp, tool_header_annotations
+
+MCP_URL = "http://testserver/mcp"
+CLIENT_HEADERS = {
+    "accept": "application/json, text/event-stream",
+    "content-type": "application/json",
+}
+
+
+def _rpc(method, params=None, request_id=1):
+    """Build a JSON-RPC request body."""
+    return {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params or {}}
+
+
+@pytest.fixture
+def strict_app():
+    """A real FastMCP HTTP app with strict header validation installed.
+
+    ``json_response`` and ``stateless_http`` keep the transport from holding an
+    SSE stream open, which is what a test client would otherwise block on.
+    """
+    return mcp.http_app(
+        transport="http",
+        json_response=True,
+        stateless_http=True,
+        middleware=[strict_header_middleware(annotation_lookup=tool_header_annotations)],
+    )
+
+
+class _Recorder:
+    """Minimal downstream ASGI app recording what it was handed."""
+
+    def __init__(self):
+        """Start with nothing recorded."""
+        self.body = None
+        self.called = False
+
+    async def __call__(self, scope, receive, send):
+        """Drain the request body and record it."""
+        self.called = True
+        chunks = []
+        while True:
+            message = await receive()
+            if message.get("type") != "http.request":
+                break
+            chunks.append(message.get("body", b"") or b"")
+            if not message.get("more_body", False):
+                break
+        self.body = b"".join(chunks)
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok", "more_body": False})
+
+
+async def _drive(app, scope, messages):
+    """Run an ASGI app over a scripted receive stream, collecting the response."""
+    pending = list(messages)
+    sent = []
+
+    async def receive():
+        """Yield the next scripted message."""
+        if pending:
+            return pending.pop(0)
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message):
+        """Record an outbound ASGI message."""
+        sent.append(message)
+
+    await app(scope, receive, send)
+    return sent
+
+
+def _scope(headers, method="POST"):
+    """Build a minimal HTTP ASGI scope."""
+    return {
+        "type": "http",
+        "method": method,
+        "path": "/mcp",
+        "headers": [(k.encode(), v.encode()) for k, v in headers.items()],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Pass-through behaviour
+# ---------------------------------------------------------------------------
+
+class TestPassThrough:
+    """Everything the middleware does not understand is forwarded untouched."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method", ["GET", "DELETE", "OPTIONS"])
+    async def test_non_post_requests_are_forwarded(self, method):
+        recorder = _Recorder()
+        await _drive(
+            StrictHeaderMiddleware(recorder),
+            _scope({"mcp-method": "nonsense"}, method=method),
+            [{"type": "http.request", "body": b"", "more_body": False}],
+        )
+        assert recorder.called is True
+
+    @pytest.mark.asyncio
+    async def test_non_http_scopes_are_forwarded(self):
+        recorder = _Recorder()
+        await _drive(StrictHeaderMiddleware(recorder), {"type": "lifespan"}, [])
+        assert recorder.called is True
+
+    @pytest.mark.asyncio
+    async def test_the_body_reaches_the_app_unchanged(self):
+        """The middleware buffers the body, so it must replay it verbatim."""
+        recorder = _Recorder()
+        body = json.dumps(_rpc("tools/list")).encode()
+        await _drive(
+            StrictHeaderMiddleware(recorder),
+            _scope(CLIENT_HEADERS),
+            [
+                {"type": "http.request", "body": body[:10], "more_body": True},
+                {"type": "http.request", "body": body[10:], "more_body": False},
+            ],
+        )
+        assert recorder.body == body
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("body", [b"not json", b"[]", b'{"result": {}}', b""])
+    async def test_unparseable_or_non_request_bodies_fail_open(self, body):
+        """A batch, a response or garbage is the transport's problem, not ours."""
+        recorder = _Recorder()
+        await _drive(
+            StrictHeaderMiddleware(recorder),
+            _scope({"mcp-method": "tools/call"}),
+            [{"type": "http.request", "body": body, "more_body": False}],
+        )
+        assert recorder.called is True
+
+    @pytest.mark.asyncio
+    async def test_an_oversized_body_is_forwarded_unvalidated(self):
+        """Buffering an unbounded body would be a memory-exhaustion vector."""
+        recorder = _Recorder()
+        body = b"x" * (MAX_BUFFERED_BODY_BYTES + 1)
+        await _drive(
+            StrictHeaderMiddleware(recorder),
+            _scope({"mcp-method": "nonsense"}),
+            [{"type": "http.request", "body": body, "more_body": False}],
+        )
+        assert recorder.called is True
+
+    @pytest.mark.asyncio
+    async def test_reads_past_the_buffer_reach_the_real_receive(self):
+        """A streaming response polls receive() for http.disconnect.
+
+        Synthesising a reply once the buffer drains would spin that poll into a
+        busy loop and starve the event loop, so the original callable has to
+        take over -- which is what actually lets an SSE response stream.
+        """
+        seen = []
+
+        async def greedy(scope, receive, send):
+            """Read one message past the end of the buffered body."""
+            seen.append(await receive())
+            seen.append(await receive())
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b"", "more_body": False})
+
+        await _drive(
+            StrictHeaderMiddleware(greedy),
+            _scope(CLIENT_HEADERS),
+            [
+                {"type": "http.request", "body": json.dumps(_rpc("tools/list")).encode(), "more_body": False},
+                {"type": "http.disconnect"},
+            ],
+        )
+
+        assert seen[1] == {"type": "http.disconnect"}
+
+    @pytest.mark.asyncio
+    async def test_a_disconnect_is_forwarded(self):
+        recorder = _Recorder()
+        await _drive(
+            StrictHeaderMiddleware(recorder),
+            _scope(CLIENT_HEADERS),
+            [{"type": "http.disconnect"}],
+        )
+        assert recorder.called is True
+
+    @pytest.mark.asyncio
+    async def test_undecodable_header_bytes_are_skipped(self):
+        """Defensive: a header name that will not decode must not raise."""
+        recorder = _Recorder()
+        scope = _scope(CLIENT_HEADERS)
+        scope["headers"].append((object(), object()))
+        await _drive(
+            StrictHeaderMiddleware(recorder),
+            scope,
+            [{"type": "http.request", "body": json.dumps(_rpc("tools/list")).encode(), "more_body": False}],
+        )
+        assert recorder.called is True
+
+
+# ---------------------------------------------------------------------------
+# Rejection behaviour
+# ---------------------------------------------------------------------------
+
+class TestRejection:
+    """A genuine header/body disagreement is rejected with HTTP 400."""
+
+    @pytest.mark.asyncio
+    async def test_a_mismatched_method_header_is_rejected_with_http_400(self):
+        """Design F6: Mismatch -> -32020 HeaderMismatch + HTTP 400.
+
+        Regression: the check used to run inside FastMCP middleware, so the
+        error was serialized into an HTTP 200 body where proxies, gateways and
+        metrics pipelines that key on status code saw a successful request.
+        """
+        recorder = _Recorder()
+        sent = await _drive(
+            StrictHeaderMiddleware(recorder),
+            _scope({**CLIENT_HEADERS, "mcp-method": "resources/read"}),
+            [{"type": "http.request", "body": json.dumps(_rpc("tools/list")).encode(), "more_body": False}],
+        )
+
+        assert recorder.called is False
+        assert sent[0]["status"] == HEADER_MISMATCH_STATUS == 400
+        payload = json.loads(sent[1]["body"])
+        assert payload["id"] == 1
+        assert payload["error"]["code"] == -32020
+        assert payload["error"]["data"]["mismatches"][0]["header"] == "Mcp-Method"
+
+    @pytest.mark.asyncio
+    async def test_a_mismatched_param_header_is_rejected(self):
+        async def lookup(name):
+            """Resolve execute_query's real annotations."""
+            return await tool_annotation_lookup(mcp, name)
+
+        body = _rpc("tools/call", {"name": "execute_query", "arguments": {"query": "up", "org_id": "tenant-9"}})
+        sent = await _drive(
+            StrictHeaderMiddleware(_Recorder(), annotation_lookup=lookup),
+            _scope({
+                **CLIENT_HEADERS,
+                "mcp-method": "tools/call",
+                "mcp-name": "execute_query",
+                "mcp-param-org-id": "tenant-OTHER",
+            }),
+            [{"type": "http.request", "body": json.dumps(body).encode(), "more_body": False}],
+        )
+
+        payload = json.loads(sent[1]["body"])
+        assert payload["error"]["data"]["mismatches"][0]["header"] == "Mcp-Param-Org-Id"
+
+    @pytest.mark.asyncio
+    async def test_a_failing_annotation_lookup_skips_the_param_headers(self):
+        """A registry outage must not turn every tools/call into a 400."""
+        async def explode(_name):
+            raise RuntimeError("registry down")
+
+        recorder = _Recorder()
+        body = _rpc("tools/call", {"name": "execute_query", "arguments": {"query": "up"}})
+        await _drive(
+            StrictHeaderMiddleware(recorder, annotation_lookup=explode),
+            _scope({**CLIENT_HEADERS, "mcp-method": "tools/call", "mcp-name": "execute_query"}),
+            [{"type": "http.request", "body": json.dumps(body).encode(), "more_body": False}],
+        )
+        assert recorder.called is True
+
+    @pytest.mark.asyncio
+    async def test_a_non_string_tool_name_skips_the_lookup(self):
+        recorder = _Recorder()
+        body = _rpc("tools/call", {"name": 42})
+        await _drive(
+            StrictHeaderMiddleware(recorder, annotation_lookup=tool_header_annotations),
+            _scope(CLIENT_HEADERS),
+            [{"type": "http.request", "body": json.dumps(body).encode(), "more_body": False}],
+        )
+        assert recorder.called is True
+
+
+# ---------------------------------------------------------------------------
+# End to end against the real server over HTTP
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_a_stock_client_completes_the_handshake_under_strict_mode(strict_app):
+    """Regression: strict mode rejected every existing client at initialize.
+
+    This drives the exact header set the official SDK's streamable-HTTP client
+    sends -- no Mcp-* hints, plus the transport-mandated MCP-Protocol-Version.
+    """
+    transport = httpx.ASGITransport(app=strict_app)
+    async with strict_app.router.lifespan_context(strict_app):
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            response = await client.post(
+                "/mcp",
+                headers=CLIENT_HEADERS,
+                json=_rpc("initialize", {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": {"name": "probe", "version": "1"},
+                }),
+            )
+
+    assert response.status_code == 200
+    assert "-32020" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_a_cold_tools_call_with_correct_2026_headers_succeeds(strict_app, monkeypatch):
+    """Regression: the first tools/call of a connection was rejected.
+
+    FastMCP warms its tool cache by re-entering its own middleware chain with an
+    internal tools/list, so validating FastMCP's per-hop method against the real
+    HTTP headers reported Mcp-Method: tools/call as a mismatch -- but only until
+    the cache was warm, making the failure depend on call ordering.
+    """
+    monkeypatch.setattr(server.config, "url", "")
+
+    transport = httpx.ASGITransport(app=strict_app)
+    async with strict_app.router.lifespan_context(strict_app):
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            session_headers = {**CLIENT_HEADERS, "mcp-protocol-version": "2025-11-25"}
+            # No tools/list first: the tool cache is deliberately cold.
+            response = await client.post(
+                "/mcp",
+                headers={**session_headers, "mcp-method": "tools/call", "mcp-name": "health_check"},
+                json=_rpc("tools/call", {"name": "health_check", "arguments": {}}, request_id=2),
+            )
+
+    assert response.status_code == 200
+    assert "-32020" not in response.text
+    assert "HeaderMismatch" not in response.text
+    assert "prometheus-mcp-server" in response.text
+
+
+@pytest.mark.asyncio
+async def test_a_genuinely_wrong_header_still_gets_http_400(strict_app):
+    """The feature must still do its job end to end."""
+    transport = httpx.ASGITransport(app=strict_app)
+    async with strict_app.router.lifespan_context(strict_app):
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            response = await client.post(
+                "/mcp",
+                headers={**CLIENT_HEADERS, "mcp-method": "resources/read"},
+                json=_rpc("tools/list"),
+            )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == -32020

--- a/tests/test_spec2026_discovery.py
+++ b/tests/test_spec2026_discovery.py
@@ -1,0 +1,541 @@
+"""Tests for the MCP 2026-07-28 server/discover layer (F4 + F8)."""
+
+import asyncio
+import json
+from typing import Literal
+from unittest.mock import MagicMock
+
+import mcp.types as mcp_types
+import pytest
+from fastmcp import Client, FastMCP
+from pydantic import BaseModel, RootModel
+
+from prometheus_mcp_server.spec2026 import discovery
+from prometheus_mcp_server.spec2026.discovery import (
+    DEFAULT_CACHE_SCOPE,
+    DEFAULT_DISCOVER_TTL_MS,
+    DISCOVER_METHOD,
+    DISCOVER_REQUIRED_KEYS,
+    build_discover_payload,
+    default_instructions,
+    install_discovery,
+    make_discover_endpoint,
+    make_discover_tool,
+)
+
+
+@pytest.fixture(scope="module")
+def installed_server():
+    """Install the discovery layer onto a dedicated FastMCP instance once."""
+    server = FastMCP("Prometheus MCP (test)")
+    status = install_discovery(
+        server,
+        "Prometheus MCP (test)",
+        "1.6.1",
+        tool_namer=lambda name: f"prom_{name}",
+    )
+    return server, status
+
+
+# ----------------------------------------------------------------------------------
+# Payload shape
+# ----------------------------------------------------------------------------------
+
+def test_payload_has_exactly_the_required_keys():
+    """The discover payload carries every key the 2026-07-28 spec requires."""
+    payload = build_discover_payload("Prometheus MCP", "1.6.1")
+
+    assert set(payload.keys()) == set(DISCOVER_REQUIRED_KEYS)
+    assert set(DISCOVER_REQUIRED_KEYS) == {
+        "resultType",
+        "supportedVersions",
+        "capabilities",
+        "instructions",
+        "ttlMs",
+        "cacheScope",
+        "_meta",
+    }
+
+
+def test_payload_default_values():
+    """Defaults match the design document's reference payload."""
+    payload = build_discover_payload("Prometheus MCP", "1.6.1")
+
+    assert payload["resultType"] == "complete"
+    assert payload["supportedVersions"] == ["2026-07-28", "2025-11-25", "2025-06-18"]
+    assert payload["ttlMs"] == DEFAULT_DISCOVER_TTL_MS
+    assert payload["cacheScope"] == DEFAULT_CACHE_SCOPE == "public"
+    assert payload["instructions"] == default_instructions("Prometheus MCP")
+    assert payload["_meta"] == {
+        "io.modelcontextprotocol/serverInfo": {"name": "Prometheus MCP", "version": "1.6.1"}
+    }
+
+
+def test_payload_is_json_serializable():
+    """The payload survives a JSON round trip unchanged."""
+    payload = build_discover_payload("Prometheus MCP", "1.6.1")
+
+    assert json.loads(json.dumps(payload)) == payload
+
+
+def test_payload_returns_a_fresh_object_each_call():
+    """Mutating a returned payload does not leak into later calls."""
+    first = build_discover_payload("A", "1")
+    first["capabilities"]["tools"]["poisoned"] = True
+    first["_meta"]["poisoned"] = True
+
+    second = build_discover_payload("A", "1")
+
+    assert second["capabilities"]["tools"] == {}
+    assert "poisoned" not in second["_meta"]
+
+
+def test_payload_overrides():
+    """Explicit arguments override every default."""
+    payload = build_discover_payload(
+        "Custom",
+        "9.9.9",
+        supported_versions=["2026-07-28"],
+        instructions="Do the thing.",
+        ttl_ms=1000,
+        cache_scope="private",
+    )
+
+    assert payload["supportedVersions"] == ["2026-07-28"]
+    assert payload["instructions"] == "Do the thing."
+    assert payload["ttlMs"] == 1000
+    assert payload["cacheScope"] == "private"
+
+
+@pytest.mark.parametrize(
+    "ttl_ms,expected",
+    [
+        (0, 0),
+        (42, 42),
+        ("500", DEFAULT_DISCOVER_TTL_MS),
+        (-1, DEFAULT_DISCOVER_TTL_MS),
+        (None, DEFAULT_DISCOVER_TTL_MS),
+        ("not-a-number", DEFAULT_DISCOVER_TTL_MS),
+        # Regression: bool subclasses int, and int() silently truncates a float,
+        # so a bare int() produced ttlMs=1 for True and 1 for 1.9 -- with no
+        # warning -- while the result envelope rejected both. The two coercion
+        # paths must agree, or the same misconfiguration is advertised two ways.
+        (True, DEFAULT_DISCOVER_TTL_MS),
+        (False, DEFAULT_DISCOVER_TTL_MS),
+        (1.9, DEFAULT_DISCOVER_TTL_MS),
+    ],
+)
+def test_ttl_ms_is_coerced_to_a_non_negative_integer(ttl_ms, expected):
+    """ttlMs must always be an integer >= 0, never a coerced bool or float."""
+    payload = build_discover_payload("A", "1", ttl_ms=ttl_ms)
+
+    assert payload["ttlMs"] == expected
+    assert isinstance(payload["ttlMs"], int)
+    assert not isinstance(payload["ttlMs"], bool)
+
+
+def test_discover_ttl_coercion_matches_the_envelope():
+    """The discovery and envelope TTL guards must not disagree."""
+    from prometheus_mcp_server.spec2026.envelope import _coerce_ttl_ms
+
+    for value in (True, False, 1.9, -1, "500", None, 0, 42):
+        envelope_default = _coerce_ttl_ms(value) != value
+        discover_default = build_discover_payload("A", "1", ttl_ms=value)["ttlMs"] != value
+        assert envelope_default == discover_default, f"disagreement on {value!r}"
+
+
+@pytest.mark.parametrize(
+    "cache_scope,expected",
+    [("public", "public"), ("private", "private"), ("bogus", "public"), (None, "public")],
+)
+def test_cache_scope_falls_back_to_public(cache_scope, expected):
+    """cacheScope is constrained to the two spec values."""
+    payload = build_discover_payload("A", "1", cache_scope=cache_scope)
+
+    assert payload["cacheScope"] == expected
+
+
+# ----------------------------------------------------------------------------------
+# F8 — extensions capability
+# ----------------------------------------------------------------------------------
+
+def test_extensions_capability_is_always_advertised():
+    """F8: capabilities always carries an extensions object, defaulting to empty."""
+    payload = build_discover_payload("A", "1")
+
+    assert payload["capabilities"] == {"tools": {}, "extensions": {}}
+
+
+def test_extensions_capability_can_be_populated():
+    """A caller-supplied extensions mapping is advertised verbatim."""
+    payload = build_discover_payload("A", "1", extensions={"io.example/thing": {"version": 1}})
+
+    assert payload["capabilities"]["extensions"] == {"io.example/thing": {"version": 1}}
+    assert payload["capabilities"]["tools"] == {}
+
+
+def test_extensions_mapping_is_copied_not_aliased():
+    """Mutating the caller's mapping afterwards does not change the payload."""
+    extensions = {"io.example/thing": {}}
+    payload = build_discover_payload("A", "1", extensions=extensions)
+    extensions["io.example/other"] = {}
+
+    assert payload["capabilities"]["extensions"] == {"io.example/thing": {}}
+
+
+def test_extra_capabilities_merge_over_the_base():
+    """Extra capabilities merge in while tools and extensions stay present."""
+    payload = build_discover_payload(
+        "A", "1", capabilities={"logging": {}, "extensions": {"io.example/from-caps": {}}}
+    )
+
+    assert payload["capabilities"]["tools"] == {}
+    assert payload["capabilities"]["logging"] == {}
+    assert payload["capabilities"]["extensions"] == {"io.example/from-caps": {}}
+
+
+def test_explicit_extensions_wins_over_capabilities_extensions():
+    """The dedicated extensions argument takes precedence."""
+    payload = build_discover_payload(
+        "A",
+        "1",
+        capabilities={"extensions": {"from": "caps"}},
+        extensions={"from": "arg"},
+    )
+
+    assert payload["capabilities"]["extensions"] == {"from": "arg"}
+
+
+# ----------------------------------------------------------------------------------
+# HTTP route
+# ----------------------------------------------------------------------------------
+
+def test_http_endpoint_returns_200_and_valid_json():
+    """GET /server/discover returns 200 with a valid, complete JSON payload."""
+    endpoint = make_discover_endpoint(lambda: build_discover_payload("Prometheus MCP", "1.6.1"))
+
+    response = asyncio.run(endpoint(MagicMock()))
+
+    assert response.status_code == 200
+    body = json.loads(response.body)
+    assert set(body.keys()) == set(DISCOVER_REQUIRED_KEYS)
+    assert body["resultType"] == "complete"
+    assert body["capabilities"]["extensions"] == {}
+    assert body["_meta"]["io.modelcontextprotocol/serverInfo"]["version"] == "1.6.1"
+
+
+def test_http_route_is_registered_on_the_app(installed_server):
+    """The route is mounted alongside the JSON-RPC endpoint."""
+    server, _ = installed_server
+
+    paths = {route.path: getattr(route, "methods", None) for route in server.http_app().routes}
+
+    assert "/server/discover" in paths
+    assert "GET" in paths["/server/discover"]
+    assert "/mcp" in paths
+
+
+# ----------------------------------------------------------------------------------
+# MCP tool
+# ----------------------------------------------------------------------------------
+
+def test_tool_function_returns_the_payload():
+    """The tool coroutine returns the shared payload."""
+    tool_fn = make_discover_tool(lambda: build_discover_payload("A", "1"))
+
+    result = asyncio.run(tool_fn())
+
+    assert set(result.keys()) == set(DISCOVER_REQUIRED_KEYS)
+
+
+@pytest.mark.asyncio
+async def test_tool_is_registered_with_the_tool_prefix(installed_server):
+    """The tool honors the caller-supplied namer (TOOL_PREFIX convention)."""
+    server, _ = installed_server
+
+    async with Client(server) as client:
+        tools = {tool.name: tool for tool in await client.list_tools()}
+
+    assert "prom_server_discover" in tools
+    assert "server_discover" not in tools
+
+
+@pytest.mark.asyncio
+async def test_tool_carries_a_complete_annotation_block(installed_server):
+    """A partial annotation block breaks the existing suite, so require a full one."""
+    server, _ = installed_server
+
+    async with Client(server) as client:
+        tool = {t.name: t for t in await client.list_tools()}["prom_server_discover"]
+
+    assert tool.annotations is not None
+    assert tool.annotations.title == "Server Discovery"
+    assert tool.annotations.title != tool.name
+    assert " " in tool.annotations.title
+    assert tool.annotations.readOnlyHint is True
+    assert tool.annotations.destructiveHint is False
+    assert tool.annotations.idempotentHint is True
+    assert tool.annotations.openWorldHint is True
+
+
+@pytest.mark.asyncio
+async def test_tool_call_returns_the_payload(installed_server):
+    """Calling the tool over MCP yields the discovery document."""
+    server, _ = installed_server
+
+    async with Client(server) as client:
+        result = await client.call_tool("prom_server_discover", {})
+
+    assert set(result.data.keys()) == set(DISCOVER_REQUIRED_KEYS)
+    assert result.data["capabilities"]["extensions"] == {}
+
+
+# ----------------------------------------------------------------------------------
+# JSON-RPC dispatch
+# ----------------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_server_discover_dispatches_as_a_real_jsonrpc_method(installed_server):
+    """server/discover is answered by the low-level server on any transport."""
+    server, status = installed_server
+    assert status["jsonrpc"] is True
+
+    async with Client(server) as client:
+        result = await client.session.send_request(
+            mcp_types.ClientRequest(discovery.DiscoverRequest()),
+            discovery.DiscoverResult,
+        )
+
+    dumped = result.model_dump(by_alias=True, mode="json", exclude_none=True)
+    assert set(dumped.keys()) == set(DISCOVER_REQUIRED_KEYS)
+    assert dumped["resultType"] == "complete"
+    assert dumped["capabilities"]["extensions"] == {}
+
+
+def test_install_status_reports_all_three_paths(installed_server):
+    """All three delivery paths install on a healthy SDK."""
+    _, status = installed_server
+
+    assert status == {"jsonrpc": True, "http_route": True, "tool": True}
+
+
+def test_install_is_idempotent(installed_server):
+    """Re-installing returns the cached status without registering duplicates."""
+    server, status = installed_server
+    routes_before = [route.path for route in server.http_app().routes]
+
+    again = install_discovery(server, "Prometheus MCP (test)", "1.6.1")
+
+    assert again == status
+    assert [route.path for route in server.http_app().routes] == routes_before
+
+
+def test_client_request_union_still_resolves_standard_methods(installed_server):
+    """Extending the union must not perturb any existing method."""
+    installed_server  # ensure the union has been extended
+
+    assert isinstance(
+        mcp_types.ClientRequest.model_validate({"method": "tools/list", "params": {}}).root,
+        mcp_types.ListToolsRequest,
+    )
+    assert isinstance(
+        mcp_types.ClientRequest.model_validate({"method": "ping", "params": {}}).root,
+        mcp_types.PingRequest,
+    )
+
+
+def test_server_discover_method_now_parses(installed_server):
+    """The extended union resolves the new method to our request model."""
+    installed_server
+
+    parsed = mcp_types.ClientRequest.model_validate({"method": DISCOVER_METHOD}).root
+
+    assert isinstance(parsed, discovery.DiscoverRequest)
+    assert parsed.params is None
+
+
+def test_genuinely_unknown_methods_are_still_rejected(installed_server):
+    """Only server/discover is added; other unknown methods still fail validation."""
+    installed_server
+
+    with pytest.raises(Exception):
+        mcp_types.ClientRequest.model_validate({"method": "bogus/method", "params": {}})
+
+
+def test_sdk_native_method_is_reused_instead_of_extending_again(installed_server):
+    """Forward compat: when the union already knows the method, do not re-extend."""
+    installed_server  # the union already contains a server/discover member
+
+    before = (
+        len(discovery._union_members(mcp_types.ClientRequest)),
+        len(discovery._union_members(mcp_types.ServerResult)),
+    )
+    fresh = FastMCP("fresh")
+    assert discovery._install_jsonrpc(fresh, lambda: build_discover_payload("A", "1")) is True
+    after = (
+        len(discovery._union_members(mcp_types.ClientRequest)),
+        len(discovery._union_members(mcp_types.ServerResult)),
+    )
+
+    assert before == after
+    found = discovery._find_member_by_method(mcp_types.ClientRequest, DISCOVER_METHOD)
+    assert fresh._mcp_server.request_handlers[found] is not None
+
+
+def test_find_member_by_method_matches_real_sdk_models():
+    """The union scan works against the SDK's own request models."""
+    found = discovery._find_member_by_method(mcp_types.ClientRequest, "tools/list")
+
+    assert found is mcp_types.ListToolsRequest
+    assert discovery._find_member_by_method(mcp_types.ClientRequest, "nope/nope") is None
+
+
+# ----------------------------------------------------------------------------------
+# Defensive degradation
+# ----------------------------------------------------------------------------------
+
+class _Stub:
+    """Bare attribute container standing in for a FastMCP instance."""
+
+
+def test_jsonrpc_install_degrades_without_a_low_level_server():
+    """A FastMCP without _mcp_server logs and returns False rather than raising."""
+    assert discovery._install_jsonrpc(_Stub(), lambda: {}) is False
+
+
+def test_jsonrpc_install_degrades_when_request_handlers_is_not_a_dict():
+    """An SDK whose dispatch table changed shape degrades cleanly."""
+    stub = _Stub()
+    stub._mcp_server = _Stub()
+    stub._mcp_server.request_handlers = "not a dict"
+
+    assert discovery._install_jsonrpc(stub, lambda: {}) is False
+
+
+def test_http_route_install_degrades_when_custom_route_fails():
+    """A custom_route failure is contained."""
+    stub = _Stub()
+    stub.custom_route = MagicMock(side_effect=RuntimeError("boom"))
+
+    assert discovery._install_http_route(stub, lambda: {}, "/server/discover") is False
+
+
+def test_tool_install_degrades_when_registration_fails():
+    """A tool registration failure is contained."""
+    stub = _Stub()
+    stub.tool = MagicMock(side_effect=RuntimeError("boom"))
+
+    assert discovery._install_tool(stub, lambda: {}, lambda name: name, "server_discover") is False
+
+
+def test_install_never_raises_on_a_hostile_object():
+    """install_discovery reports failure for every path instead of raising."""
+    stub = _Stub()
+    stub.custom_route = MagicMock(side_effect=RuntimeError("boom"))
+    stub.tool = MagicMock(side_effect=RuntimeError("boom"))
+
+    status = install_discovery(stub, "A", "1")
+
+    assert status == {"jsonrpc": False, "http_route": False, "tool": False}
+
+
+def test_jsonrpc_install_degrades_when_the_models_are_undefined(monkeypatch):
+    """An SDK whose base models vanished leaves DiscoverRequest as None."""
+    monkeypatch.setattr(discovery, "DiscoverRequest", None)
+
+    assert discovery._install_jsonrpc(FastMCP("undefined"), lambda: {}) is False
+
+
+def test_jsonrpc_install_degrades_when_union_surgery_raises(monkeypatch):
+    """Any unexpected failure inside the installer is contained and logged."""
+    monkeypatch.setattr(
+        discovery,
+        "_find_member_by_method",
+        MagicMock(side_effect=RuntimeError("SDK changed shape")),
+    )
+
+    assert discovery._install_jsonrpc(FastMCP("raises"), lambda: {}) is False
+
+
+def test_jsonrpc_install_degrades_when_the_root_field_is_absent(monkeypatch):
+    """An SDK that stops modelling requests as a RootModel union degrades cleanly."""
+
+    class _NoRoot(BaseModel):
+        """Stands in for a restructured mcp.types.ClientRequest."""
+
+    monkeypatch.setattr(mcp_types, "ClientRequest", _NoRoot)
+
+    assert discovery._install_jsonrpc(FastMCP("no-root"), lambda: {}) is False
+
+
+def test_union_scan_skips_non_model_members():
+    """Union members that are not pydantic models are ignored, not crashed on."""
+
+    class _Member(BaseModel):
+        method: Literal["x/y"] = "x/y"
+
+    class _Root(RootModel[int | _Member]):
+        pass
+
+    assert discovery._find_member_by_method(_Root, "x/y") is _Member
+    assert discovery._find_member_by_method(_Root, "other/method") is None
+
+
+def test_constants_module_is_optional(monkeypatch):
+    """A missing spec2026.constants degrades to the design-doc literals."""
+    monkeypatch.setattr(
+        discovery.importlib, "import_module", MagicMock(side_effect=ImportError("gone"))
+    )
+    assert discovery._load_constants() is None
+
+    monkeypatch.setattr(discovery, "_constants", None)
+    assert discovery._const("PROTOCOL_VERSION_2026", "2026-07-28") == "2026-07-28"
+
+
+def test_constants_are_sourced_from_the_shared_module():
+    """When present, the shared constants module is the source of truth."""
+    from prometheus_mcp_server.spec2026 import constants
+
+    assert discovery.PROTOCOL_VERSION_2026 == constants.PROTOCOL_VERSION_2026
+    assert discovery.SUPPORTED_PROTOCOL_VERSIONS == tuple(constants.SUPPORTED_PROTOCOL_VERSIONS)
+    assert discovery.META_SERVER_INFO == constants.META_SERVER_INFO
+    assert discovery.RESULT_TYPE_COMPLETE == constants.RESULT_TYPE_COMPLETE
+
+
+def test_union_extension_rolls_back_when_rebuild_fails():
+    """A failed model_rebuild restores the original annotation."""
+
+    class _Member(BaseModel):
+        pass
+
+    class _Root(RootModel[int]):
+        pass
+
+    original = _Root.model_fields["root"].annotation
+    calls = {"n": 0}
+
+    def _exploding_rebuild(**kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("rebuild failed")
+        return True
+
+    _Root.model_rebuild = _exploding_rebuild
+
+    with pytest.raises(RuntimeError):
+        discovery._extend_union(_Root, _Member)
+
+    assert _Root.model_fields["root"].annotation is original
+    assert calls["n"] == 2  # failed extend, then successful restore
+
+
+def test_custom_payload_factory_feeds_every_path():
+    """The payload_factory escape hatch overrides the built-in builder."""
+    server = FastMCP("factory")
+    sentinel = {"resultType": "complete", "custom": True}
+
+    status = install_discovery(server, "A", "1", payload_factory=lambda: dict(sentinel))
+    endpoint_body = json.loads(asyncio.run(make_discover_endpoint(lambda: dict(sentinel))(MagicMock())).body)
+
+    assert status["http_route"] is True
+    assert endpoint_body == sentinel

--- a/tests/test_spec2026_envelope.py
+++ b/tests/test_spec2026_envelope.py
@@ -1,0 +1,814 @@
+#!/usr/bin/env python
+
+"""Tests for the MCP 2026-07-28 result envelope layer (F2 + F3)."""
+
+from unittest.mock import MagicMock, patch
+
+import mcp.types as types
+import pytest
+from fastmcp import Client
+
+from prometheus_mcp_server.server import clear_metrics_cache, mcp
+from prometheus_mcp_server.spec2026.envelope import (
+    CACHEABLE_METHODS,
+    DEFAULT_CACHE_SCOPE,
+    DEFAULT_CACHE_TTL_MS,
+    _WRAPPER_MARKER,
+    enrich_result,
+    install_envelope,
+    uninstall_envelope,
+)
+
+SERVER_NAME = "Prometheus MCP"
+SERVER_VERSION = "1.6.1"
+SERVER_INFO_KEY = "io.modelcontextprotocol/serverInfo"
+
+
+@pytest.fixture(autouse=True)
+def restore_server_state():
+    """Keep the shared FastMCP singleton and metrics cache clean between tests.
+
+    These tests install and uninstall the envelope on the module-level FastMCP
+    singleton that server.py already wrapped at import. The teardown therefore
+    *restores* the handler dict to whatever it was on entry rather than calling
+    uninstall_envelope, which would strip the production wrappers and leave the
+    shared server in a non-production state for the rest of the pytest process.
+    """
+    clear_metrics_cache()
+    handlers = mcp._mcp_server.request_handlers
+    saved = dict(handlers)
+    yield
+    handlers.clear()
+    handlers.update(saved)
+    clear_metrics_cache()
+
+
+@pytest.fixture
+def installed():
+    """Install the envelope on the real server with known settings."""
+    assert install_envelope(
+        mcp,
+        server_name=SERVER_NAME,
+        server_version=SERVER_VERSION,
+        ttl_ms=300000,
+        cache_scope="public",
+    )
+    return mcp
+
+
+def make_stub_mcp(handlers):
+    """Build a minimal object shaped like a FastMCP server."""
+    low_level = MagicMock()
+    low_level.request_handlers = handlers
+    stub = MagicMock()
+    stub._mcp_server = low_level
+    return stub
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through a real in-memory MCP client
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tools_list_carries_full_envelope(installed):
+    """tools/list gains resultType, ttlMs, cacheScope, serverInfo and sorted tools."""
+    async with Client(mcp) as client:
+        result = await client.session.list_tools()
+
+    payload = result.model_dump(by_alias=True, mode="json", exclude_none=True)
+    assert payload["resultType"] == "complete"
+    assert payload["ttlMs"] == 300000
+    assert payload["cacheScope"] == "public"
+    assert payload["_meta"][SERVER_INFO_KEY] == {
+        "name": SERVER_NAME,
+        "version": SERVER_VERSION,
+    }
+
+    names = [tool.name for tool in result.tools]
+    assert names == sorted(names)
+    assert len(names) > 1, "need several tools for the ordering assertion to mean anything"
+
+
+@pytest.mark.asyncio
+async def test_tools_call_has_no_cache_fields(installed):
+    """tools/call is not cacheable: resultType and serverInfo only."""
+    with patch("prometheus_mcp_server.server.make_prometheus_request") as mock_request:
+        mock_request.return_value = {"resultType": "vector", "result": []}
+        async with Client(mcp) as client:
+            result = await client.session.call_tool("execute_query", {"query": "up"})
+
+    payload = result.model_dump(by_alias=True, mode="json", exclude_none=True)
+    assert payload["resultType"] == "complete"
+    assert payload["_meta"][SERVER_INFO_KEY]["name"] == SERVER_NAME
+    assert "ttlMs" not in payload
+    assert "cacheScope" not in payload
+
+
+@pytest.mark.asyncio
+async def test_ping_carries_result_type(installed):
+    """Every result gets resultType, including the empty ping result."""
+    async with Client(mcp) as client:
+        await client.ping()
+        result = await client.session.send_request(
+            types.ClientRequest(types.PingRequest()), types.EmptyResult
+        )
+
+    payload = result.model_dump(by_alias=True, mode="json", exclude_none=True)
+    assert payload["resultType"] == "complete"
+    assert "ttlMs" not in payload
+
+
+@pytest.mark.asyncio
+async def test_uninstall_restores_plain_results():
+    """Removing the layer leaves the SDK's untouched results behind."""
+    install_envelope(mcp, server_name=SERVER_NAME, server_version=SERVER_VERSION)
+    assert uninstall_envelope(mcp) is True
+
+    async with Client(mcp) as client:
+        result = await client.session.list_tools()
+
+    payload = result.model_dump(by_alias=True, mode="json", exclude_none=True)
+    assert "resultType" not in payload
+    assert "ttlMs" not in payload
+    assert "_meta" not in payload
+
+
+# ---------------------------------------------------------------------------
+# Installation behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_install_is_idempotent(installed):
+    """A second install replaces the wrappers instead of nesting them."""
+    handlers = mcp._mcp_server.request_handlers
+    first = dict(handlers)
+
+    assert install_envelope(
+        mcp, server_name=SERVER_NAME, server_version=SERVER_VERSION
+    )
+
+    assert set(handlers) == set(first)
+    for request_type, handler in handlers.items():
+        inner = getattr(handler, _WRAPPER_MARKER, None)
+        assert inner is not None, f"{request_type.__name__} lost its wrapper"
+        assert not hasattr(inner, _WRAPPER_MARKER), "wrappers were nested"
+        assert inner is getattr(first[request_type], _WRAPPER_MARKER)
+
+
+@pytest.mark.asyncio
+async def test_reinstall_updates_settings(installed):
+    """Re-installing with new settings takes effect rather than being ignored."""
+    install_envelope(
+        mcp,
+        server_name="Other Server",
+        server_version="9.9.9",
+        ttl_ms=1000,
+        cache_scope="private",
+    )
+
+    async with Client(mcp) as client:
+        result = await client.session.list_tools()
+
+    payload = result.model_dump(by_alias=True, mode="json", exclude_none=True)
+    assert payload["ttlMs"] == 1000
+    assert payload["cacheScope"] == "private"
+    assert payload["_meta"][SERVER_INFO_KEY] == {"name": "Other Server", "version": "9.9.9"}
+
+
+def test_uninstall_without_install_is_a_noop():
+    """Uninstalling a server that was never wrapped reports no work done."""
+    stub = make_stub_mcp({types.ListToolsRequest: lambda req: None})
+
+    assert uninstall_envelope(stub) is False
+    # The untouched handler is left exactly as it was found.
+    assert not hasattr(stub._mcp_server.request_handlers[types.ListToolsRequest], _WRAPPER_MARKER)
+
+
+def test_uninstall_is_idempotent(installed):
+    """The second uninstall of a real server finds nothing left to restore."""
+    assert uninstall_envelope(mcp) is True
+    assert uninstall_envelope(mcp) is False
+
+
+# ---------------------------------------------------------------------------
+# Defensive degradation
+# ---------------------------------------------------------------------------
+
+
+def test_install_without_low_level_server_degrades():
+    """A FastMCP without _mcp_server logs a warning and returns False."""
+    stub = object()
+    with patch("prometheus_mcp_server.spec2026.envelope.logger") as mock_logger:
+        assert (
+            install_envelope(stub, server_name=SERVER_NAME, server_version=SERVER_VERSION)
+            is False
+        )
+    mock_logger.warning.assert_called_once()
+
+
+def test_install_without_handler_dict_degrades():
+    """request_handlers that is not a dict logs a warning and returns False."""
+    stub = make_stub_mcp(["not", "a", "dict"])
+    with patch("prometheus_mcp_server.spec2026.envelope.logger") as mock_logger:
+        assert (
+            install_envelope(stub, server_name=SERVER_NAME, server_version=SERVER_VERSION)
+            is False
+        )
+    mock_logger.warning.assert_called_once()
+
+
+def test_uninstall_without_low_level_server_degrades():
+    """uninstall_envelope tolerates an unexpected server shape."""
+    assert uninstall_envelope(object()) is False
+
+
+def test_install_skips_non_callable_handlers():
+    """A junk handler is skipped without aborting the whole install."""
+    handlers = {types.ListToolsRequest: "not callable"}
+    stub = make_stub_mcp(handlers)
+    with patch("prometheus_mcp_server.spec2026.envelope.logger") as mock_logger:
+        assert (
+            install_envelope(stub, server_name=SERVER_NAME, server_version=SERVER_VERSION)
+            is False
+        )
+    assert mock_logger.warning.call_count == 2  # skipped handler + layer inactive
+    assert handlers[types.ListToolsRequest] == "not callable"
+
+
+@pytest.mark.asyncio
+async def test_install_wraps_unknown_request_types():
+    """A request type with no method Literal still gets resultType, uncached."""
+
+    class MysteryRequest:
+        pass
+
+    async def handler(req):
+        return types.ServerResult(types.EmptyResult())
+
+    handlers = {MysteryRequest: handler}
+    stub = make_stub_mcp(handlers)
+    assert install_envelope(
+        stub, server_name=SERVER_NAME, server_version=SERVER_VERSION
+    )
+
+    result = await handlers[MysteryRequest](None)
+    assert result.root.resultType == "complete"
+    assert not hasattr(result.root, "ttlMs")
+
+
+@pytest.mark.asyncio
+async def test_enrichment_failure_still_returns_the_result():
+    """If envelope assignment blows up, the client still gets its response."""
+
+    class Hostile:
+        root = None
+
+        def __setattr__(self, name, value):
+            raise RuntimeError("no mutation allowed")
+
+    sentinel = Hostile()
+
+    async def handler(req):
+        return sentinel
+
+    handlers = {types.ListToolsRequest: handler}
+    stub = make_stub_mcp(handlers)
+    assert install_envelope(
+        stub, server_name=SERVER_NAME, server_version=SERVER_VERSION
+    )
+
+    with patch("prometheus_mcp_server.spec2026.envelope.logger") as mock_logger:
+        result = await handlers[types.ListToolsRequest](None)
+
+    assert result is sentinel
+    mock_logger.warning.assert_called_once()
+
+
+def test_install_survives_a_failing_handler_swap():
+    """A handler dict that rejects writes degrades instead of raising."""
+
+    class HostileDict(dict):
+        def __setitem__(self, key, value):
+            raise RuntimeError("read-only handler table")
+
+    async def handler(req):
+        return types.ServerResult(types.EmptyResult())
+
+    handlers = HostileDict({types.ListToolsRequest: handler})
+    stub = make_stub_mcp(handlers)
+    with patch("prometheus_mcp_server.spec2026.envelope.logger") as mock_logger:
+        assert (
+            install_envelope(stub, server_name=SERVER_NAME, server_version=SERVER_VERSION)
+            is False
+        )
+    assert mock_logger.warning.call_count == 2  # per-handler failure + layer inactive
+
+
+def test_install_never_raises_on_unexpected_failure():
+    """The outermost guard converts any surprise into a logged warning."""
+    with patch(
+        "prometheus_mcp_server.spec2026.envelope._get_request_handlers",
+        side_effect=RuntimeError("boom"),
+    ):
+        with patch("prometheus_mcp_server.spec2026.envelope.logger") as mock_logger:
+            assert (
+                install_envelope(
+                    mcp, server_name=SERVER_NAME, server_version=SERVER_VERSION
+                )
+                is False
+            )
+    mock_logger.warning.assert_called_once()
+
+
+def test_uninstall_never_raises_on_unexpected_failure():
+    """uninstall_envelope has the same never-raise guarantee."""
+    with patch(
+        "prometheus_mcp_server.spec2026.envelope._get_request_handlers",
+        side_effect=RuntimeError("boom"),
+    ):
+        with patch("prometheus_mcp_server.spec2026.envelope.logger") as mock_logger:
+            assert uninstall_envelope(mcp) is False
+    mock_logger.warning.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_install_supports_sync_handlers():
+    """A non-coroutine handler is enriched rather than awaited blindly."""
+
+    def handler(req):
+        return types.ServerResult(types.ListToolsResult(tools=[]))
+
+    handlers = {types.ListToolsRequest: handler}
+    stub = make_stub_mcp(handlers)
+    assert install_envelope(
+        stub, server_name=SERVER_NAME, server_version=SERVER_VERSION
+    )
+
+    result = await handlers[types.ListToolsRequest](None)
+    assert result.root.resultType == "complete"
+    assert result.root.ttlMs == DEFAULT_CACHE_TTL_MS
+
+
+# ---------------------------------------------------------------------------
+# Setting validation
+# ---------------------------------------------------------------------------
+
+
+async def install_and_list(stub_handlers, **kwargs):
+    """Install on a stub server and return the enriched tools/list result."""
+    stub = make_stub_mcp(stub_handlers)
+    assert install_envelope(
+        stub, server_name=SERVER_NAME, server_version=SERVER_VERSION, **kwargs
+    )
+    result = await stub_handlers[types.ListToolsRequest](None)
+    return result.root
+
+
+def make_list_tools_handler():
+    """Build a stub tools/list handler returning a fresh empty result."""
+
+    async def handler(req):
+        return types.ServerResult(types.ListToolsResult(tools=[]))
+
+    return {types.ListToolsRequest: handler}
+
+
+@pytest.mark.parametrize("bad_ttl", [-1, "300000", 1.5, True, None])
+@pytest.mark.asyncio
+async def test_invalid_ttl_falls_back_to_default(bad_ttl):
+    """Only a non-negative int is accepted as ttlMs."""
+    with patch("prometheus_mcp_server.spec2026.envelope.logger") as mock_logger:
+        result = await install_and_list(make_list_tools_handler(), ttl_ms=bad_ttl)
+
+    assert result.ttlMs == DEFAULT_CACHE_TTL_MS
+    mock_logger.warning.assert_called_once()
+
+
+@pytest.mark.parametrize("bad_scope", ["shared", "", None, 1])
+@pytest.mark.asyncio
+async def test_invalid_cache_scope_falls_back_to_default(bad_scope):
+    """Only "public" or "private" is accepted as cacheScope."""
+    with patch("prometheus_mcp_server.spec2026.envelope.logger") as mock_logger:
+        result = await install_and_list(make_list_tools_handler(), cache_scope=bad_scope)
+
+    assert result.cacheScope == DEFAULT_CACHE_SCOPE
+    mock_logger.warning.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_private_cache_scope_is_accepted():
+    """"private" is a legal scope and is not coerced away."""
+    with patch("prometheus_mcp_server.spec2026.envelope.logger") as mock_logger:
+        result = await install_and_list(make_list_tools_handler(), cache_scope="private")
+
+    assert result.cacheScope == "private"
+    mock_logger.warning.assert_not_called()
+
+
+def test_zero_ttl_is_valid():
+    """ttlMs of 0 is a legal "do not cache" hint, not a falsy fallback."""
+    result = types.ListToolsResult(tools=[])
+    enrich_result(
+        result,
+        method="tools/list",
+        server_name=SERVER_NAME,
+        server_version=SERVER_VERSION,
+        ttl_ms=0,
+    )
+    assert result.ttlMs == 0
+
+
+# ---------------------------------------------------------------------------
+# enrich_result unit behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_existing_meta_is_merged_not_clobbered():
+    """Pre-existing _meta keys survive the serverInfo merge."""
+    result = types.ListToolsResult(tools=[], _meta={"traceparent": "abc", "custom": {"a": 1}})
+    enrich_result(
+        result,
+        method="tools/list",
+        server_name=SERVER_NAME,
+        server_version=SERVER_VERSION,
+    )
+    assert result.meta["traceparent"] == "abc"
+    assert result.meta["custom"] == {"a": 1}
+    assert result.meta[SERVER_INFO_KEY] == {"name": SERVER_NAME, "version": SERVER_VERSION}
+
+
+def test_existing_envelope_fields_are_preserved():
+    """A handler that built its own envelope stays authoritative."""
+    result = types.ListToolsResult(tools=[], _meta={SERVER_INFO_KEY: {"name": "mine"}})
+    result.resultType = "input_required"
+    result.ttlMs = 42
+    result.cacheScope = "private"
+
+    enrich_result(
+        result,
+        method="tools/list",
+        server_name=SERVER_NAME,
+        server_version=SERVER_VERSION,
+        ttl_ms=300000,
+        cache_scope="public",
+    )
+
+    assert result.resultType == "input_required"
+    assert result.ttlMs == 42
+    assert result.cacheScope == "private"
+    assert result.meta[SERVER_INFO_KEY] == {"name": "mine"}
+
+
+def test_enrich_result_is_idempotent():
+    """Applying the envelope twice changes nothing the second time."""
+    result = types.ListToolsResult(tools=[])
+    kwargs = {
+        "method": "tools/list",
+        "server_name": SERVER_NAME,
+        "server_version": SERVER_VERSION,
+    }
+    enrich_result(result, **kwargs)
+    first = result.model_dump(by_alias=True, mode="json", exclude_none=True)
+    enrich_result(result, **kwargs)
+    assert result.model_dump(by_alias=True, mode="json", exclude_none=True) == first
+
+
+def test_enrich_result_unwraps_server_result():
+    """Passing the ServerResult wrapper enriches the concrete result inside it."""
+    inner = types.ListToolsResult(tools=[])
+    wrapper = types.ServerResult(inner)
+    returned = enrich_result(
+        wrapper,
+        method="tools/list",
+        server_name=SERVER_NAME,
+        server_version=SERVER_VERSION,
+    )
+    assert returned is wrapper
+    assert wrapper.root.resultType == "complete"
+    dumped = wrapper.model_dump(by_alias=True, mode="json", exclude_none=True)
+    assert dumped["resultType"] == "complete"
+    assert dumped["ttlMs"] == DEFAULT_CACHE_TTL_MS
+
+
+def test_non_mapping_meta_is_left_alone():
+    """An unexpected _meta type is reported, not overwritten."""
+    result = types.ListToolsResult(tools=[])
+    object.__setattr__(result, "__dict__", {**result.__dict__, "meta": "not-a-dict"})
+
+    with patch("prometheus_mcp_server.spec2026.envelope.logger") as mock_logger:
+        enrich_result(
+            result,
+            method="tools/list",
+            server_name=SERVER_NAME,
+            server_version=SERVER_VERSION,
+        )
+
+    assert result.meta == "not-a-dict"
+    mock_logger.warning.assert_called_once()
+
+
+@pytest.mark.parametrize("method", sorted(CACHEABLE_METHODS))
+def test_cacheable_methods_get_cache_fields(method):
+    """Every method in the cacheable set carries ttlMs and cacheScope."""
+    result = types.EmptyResult()
+    enrich_result(
+        result,
+        method=method,
+        server_name=SERVER_NAME,
+        server_version=SERVER_VERSION,
+    )
+    assert result.ttlMs == DEFAULT_CACHE_TTL_MS
+    assert result.cacheScope == DEFAULT_CACHE_SCOPE
+
+
+@pytest.mark.parametrize("method", ["tools/call", "prompts/get", "ping", "logging/setLevel", None])
+def test_non_cacheable_methods_have_no_cache_fields(method):
+    """tools/call and friends must not advertise a cache lifetime."""
+    result = types.EmptyResult()
+    enrich_result(
+        result,
+        method=method,
+        server_name=SERVER_NAME,
+        server_version=SERVER_VERSION,
+    )
+    assert result.resultType == "complete"
+    assert not hasattr(result, "ttlMs")
+    assert not hasattr(result, "cacheScope")
+
+
+# ---------------------------------------------------------------------------
+# Deterministic ordering (F3)
+# ---------------------------------------------------------------------------
+
+
+def test_prompts_are_sorted_by_name():
+    """prompts/list is ordered deterministically."""
+    result = types.ListPromptsResult(
+        prompts=[types.Prompt(name=name) for name in ["zeta", "alpha", "mid"]]
+    )
+    enrich_result(
+        result,
+        method="prompts/list",
+        server_name=SERVER_NAME,
+        server_version=SERVER_VERSION,
+    )
+    assert [p.name for p in result.prompts] == ["alpha", "mid", "zeta"]
+
+
+def test_resources_are_sorted_by_name_then_uri():
+    """Same-named resources fall back to URI ordering for stability."""
+    result = types.ListResourcesResult(
+        resources=[
+            types.Resource(name="dup", uri="http://b/2"),
+            types.Resource(name="aaa", uri="http://a/1"),
+            types.Resource(name="dup", uri="http://a/1"),
+        ]
+    )
+    enrich_result(
+        result,
+        method="resources/list",
+        server_name=SERVER_NAME,
+        server_version=SERVER_VERSION,
+    )
+    assert [(r.name, str(r.uri)) for r in result.resources] == [
+        ("aaa", "http://a/1"),
+        ("dup", "http://a/1"),
+        ("dup", "http://b/2"),
+    ]
+
+
+def test_resource_templates_are_sorted():
+    """resources/templates/list is ordered deterministically."""
+    result = types.ListResourceTemplatesResult(
+        resourceTemplates=[
+            types.ResourceTemplate(name="z", uriTemplate="http://z/{id}"),
+            types.ResourceTemplate(name="a", uriTemplate="http://a/{id}"),
+        ]
+    )
+    enrich_result(
+        result,
+        method="resources/templates/list",
+        server_name=SERVER_NAME,
+        server_version=SERVER_VERSION,
+    )
+    assert [t.name for t in result.resourceTemplates] == ["a", "z"]
+
+
+def test_read_resource_result_is_untouched_by_sorting():
+    """resources/read has no listable collection but still gets cache fields."""
+    result = types.ReadResourceResult(contents=[])
+    enrich_result(
+        result,
+        method="resources/read",
+        server_name=SERVER_NAME,
+        server_version=SERVER_VERSION,
+    )
+    assert result.contents == []
+    assert result.ttlMs == DEFAULT_CACHE_TTL_MS
+    assert result.cacheScope == DEFAULT_CACHE_SCOPE
+
+
+# ---------------------------------------------------------------------------
+# Regressions found by adversarial review
+# ---------------------------------------------------------------------------
+
+class TestEnrichResultValidatesItsEnvelopeFields:
+    """enrich_result is public API and must not emit a spec-invalid envelope."""
+
+    @pytest.mark.parametrize("ttl_ms", [-5000, 1.5, True, False, "300000", None])
+    def test_an_invalid_ttl_falls_back_to_the_default(self, ttl_ms):
+        """Regression: ttlMs was written through unchecked, so a negative,
+        float or boolean value reached the wire despite the docstring
+        promising an integer >= 0."""
+        result = types.ListToolsResult(tools=[])
+
+        enrich_result(
+            result,
+            method="tools/list",
+            server_name=SERVER_NAME,
+            server_version=SERVER_VERSION,
+            ttl_ms=ttl_ms,
+        )
+
+        payload = result.model_dump(by_alias=True, exclude_none=True)
+        assert payload["ttlMs"] == DEFAULT_CACHE_TTL_MS
+        assert isinstance(payload["ttlMs"], int) and not isinstance(payload["ttlMs"], bool)
+
+    @pytest.mark.parametrize("cache_scope", ["shared", "PUBLIC", None, 42])
+    def test_an_invalid_cache_scope_falls_back_to_the_default(self, cache_scope):
+        """Regression: an arbitrary cacheScope was emitted verbatim, and None
+        produced a cacheable result carrying ttlMs but no cacheScope at all."""
+        result = types.ListToolsResult(tools=[])
+
+        enrich_result(
+            result,
+            method="tools/list",
+            server_name=SERVER_NAME,
+            server_version=SERVER_VERSION,
+            cache_scope=cache_scope,
+        )
+
+        payload = result.model_dump(by_alias=True, exclude_none=True)
+        assert payload["cacheScope"] == DEFAULT_CACHE_SCOPE
+        assert payload["cacheScope"] in ("public", "private")
+
+    def test_valid_values_are_still_honoured(self):
+        """The guard must not flatten legitimate configuration."""
+        result = types.ListToolsResult(tools=[])
+
+        enrich_result(
+            result,
+            method="tools/list",
+            server_name=SERVER_NAME,
+            server_version=SERVER_VERSION,
+            ttl_ms=0,
+            cache_scope="private",
+        )
+
+        payload = result.model_dump(by_alias=True, exclude_none=True)
+        assert payload["ttlMs"] == 0
+        assert payload["cacheScope"] == "private"
+
+
+class TestResourceNotFoundErrorCode:
+    """F1: resource-not-found moved from -32002 to -32602."""
+
+    @pytest.mark.asyncio
+    async def test_a_missing_resource_reports_invalid_params(self):
+        """Regression: INVALID_PARAMS was defined in constants but never wired,
+        so the SDK's 2025-11-25 -32002 reached the client unchanged."""
+        from mcp.shared.exceptions import McpError
+
+        async with Client(mcp) as client:
+            with pytest.raises(McpError) as excinfo:
+                await client.session.send_request(
+                    types.ClientRequest(
+                        types.ReadResourceRequest(
+                            params=types.ReadResourceRequestParams(uri="file:///nope")
+                        )
+                    ),
+                    types.ReadResourceResult,
+                )
+
+        assert excinfo.value.error.code == -32602
+        assert "nope" in excinfo.value.error.message
+
+    @pytest.mark.asyncio
+    async def test_other_methods_keep_their_error_codes(self):
+        """Only resources/read changed; nothing else may be retyped."""
+        from mcp.shared.exceptions import McpError
+        from mcp.types import ErrorData
+
+        from prometheus_mcp_server.spec2026.envelope import _retype_error
+
+        error = McpError(ErrorData(code=-32002, message="Resource not found: x"))
+
+        assert _retype_error(error, "tools/call") is error
+        assert _retype_error(error, None) is error
+        assert _retype_error(ValueError("boom"), "resources/read").__class__ is ValueError
+        assert _retype_error(
+            McpError(ErrorData(code=-32603, message="internal")), "resources/read"
+        ).error.code == -32603
+
+
+class TestInitializeEnvelope:
+    """F2 requires the envelope on *all* results, including the handshake."""
+
+    @pytest.mark.asyncio
+    async def test_the_handshake_result_carries_the_envelope(self):
+        """Regression: InitializeRequest is answered inside ServerSession and
+        never reaches request_handlers, so a 2026-07-28 client was guaranteed
+        at least one envelope-less result on every connection."""
+        async with Client(mcp) as client:
+            payload = client.initialize_result.model_dump(by_alias=True, exclude_none=True)
+
+        assert payload["resultType"] == "complete"
+        assert payload["_meta"][SERVER_INFO_KEY] == {
+            "name": SERVER_NAME,
+            "version": SERVER_VERSION,
+        }
+        # initialize is not cacheable.
+        assert "ttlMs" not in payload
+        assert "cacheScope" not in payload
+
+    @pytest.mark.asyncio
+    async def test_install_and_uninstall_are_idempotent(self):
+        """The session class is process-global, so the patch must be reversible."""
+        from prometheus_mcp_server.spec2026.envelope import (
+            install_initialize_envelope,
+            uninstall_initialize_envelope,
+        )
+
+        try:
+            assert install_initialize_envelope(
+                server_name=SERVER_NAME, server_version=SERVER_VERSION
+            ) is True
+            assert install_initialize_envelope(
+                server_name=SERVER_NAME, server_version=SERVER_VERSION
+            ) is True
+
+            assert uninstall_initialize_envelope() is True
+            assert uninstall_initialize_envelope() is False
+
+            async with Client(mcp) as client:
+                payload = client.initialize_result.model_dump(by_alias=True, exclude_none=True)
+            assert "resultType" not in payload
+        finally:
+            install_initialize_envelope(
+                server_name=SERVER_NAME, server_version=SERVER_VERSION
+            )
+
+    @pytest.mark.asyncio
+    async def test_a_failing_enrichment_still_completes_the_handshake(self):
+        """A broken envelope must never cost the client its connection."""
+        from prometheus_mcp_server.spec2026 import envelope as envelope_module
+
+        with patch.object(envelope_module, "enrich_result", side_effect=RuntimeError("boom")):
+            async with Client(mcp) as client:
+                assert client.initialize_result.serverInfo.name == SERVER_NAME
+
+    def test_install_degrades_when_the_sdk_shape_changes(self):
+        """An incompatible SDK is logged, not raised."""
+        from prometheus_mcp_server.spec2026 import envelope as envelope_module
+
+        with patch.dict("sys.modules", {"mcp.server.session": None}):
+            assert envelope_module.install_initialize_envelope(
+                server_name=SERVER_NAME, server_version=SERVER_VERSION
+            ) is False
+
+
+class TestRetypeErrorGuards:
+    """Defensive branches of the resource-not-found error retyping."""
+
+    def test_a_non_mcp_error_carrying_the_code_is_left_alone(self):
+        """Only the SDK's own McpError may be rebuilt."""
+        from prometheus_mcp_server.spec2026.envelope import _retype_error
+
+        class Lookalike(Exception):
+            """Not an McpError, but shaped like one."""
+
+            error = MagicMock(code=-32002, message="Resource not found: x", data=None)
+
+        error = Lookalike()
+        assert _retype_error(error, "resources/read") is error
+
+    @pytest.mark.asyncio
+    async def test_an_unrelated_handler_failure_propagates_unchanged(self):
+        """A non-retyped exception keeps its original traceback."""
+        from prometheus_mcp_server.spec2026.envelope import _wrap_handler
+
+        async def handler(_req):
+            raise ValueError("boom")
+
+        wrapped = _wrap_handler(
+            handler,
+            method="resources/read",
+            server_name=SERVER_NAME,
+            server_version=SERVER_VERSION,
+            ttl_ms=DEFAULT_CACHE_TTL_MS,
+            cache_scope=DEFAULT_CACHE_SCOPE,
+        )
+
+        with pytest.raises(ValueError, match="boom"):
+            await wrapped(None)

--- a/tests/test_spec2026_headers.py
+++ b/tests/test_spec2026_headers.py
@@ -1,0 +1,1177 @@
+"""Tests for MCP 2026-07-28 HTTP header validation and x-mcp-header support (F6).
+
+Covers the three independent concerns of
+``prometheus_mcp_server.spec2026.headers``:
+
+- The base64 sentinel codec, including every example given in the spec.
+- ``Mcp-Method`` / ``Mcp-Name`` / ``MCP-Protocol-Version`` / ``Mcp-Param-*``
+  validation against the JSON-RPC body, including numeric comparison.
+- ``x-mcp-header`` input-schema validation and value extraction.
+"""
+
+import pytest
+
+from prometheus_mcp_server.spec2026.headers import (
+    ANNOTATION_KEY,
+    HEADER_MCP_METHOD,
+    HEADER_MCP_NAME,
+    HEADER_MCP_PROTOCOL_VERSION,
+    HEADER_MISMATCH,
+    META_PROTOCOL_VERSION,
+    PARAM_HEADER_PREFIX,
+    SENTINEL_PREFIX,
+    SENTINEL_SUFFIX,
+    HeaderAnnotation,
+    collect_header_annotations,
+    decode_header_value,
+    encode_header_value,
+    extract_param_headers,
+    header_mismatch_error,
+    is_safe_plain_ascii,
+    looks_like_sentinel,
+    strict_headers_enabled,
+    validate_header_annotations,
+    validate_request_headers,
+)
+
+
+def _codes(errors):
+    """Collapse schema annotation errors to their machine-readable codes."""
+    return [error.code for error in errors]
+
+
+def _reasons(errors):
+    """Collapse header validation errors to their machine-readable reasons."""
+    return [error.reason for error in errors]
+
+
+# ---------------------------------------------------------------------------
+# (A) Base64 sentinel codec
+# ---------------------------------------------------------------------------
+
+class TestBase64SentinelCodec:
+    """The =?base64?{b64}?= codec."""
+
+    @pytest.mark.parametrize("value,expected", [
+        ("us-west1", "us-west1"),
+        ("Hello, 世界", "=?base64?SGVsbG8sIOS4lueVjA==?="),
+        (" padded ", "=?base64?IHBhZGRlZCA=?="),
+        ("line1\nline2", "=?base64?bGluZTEKbGluZTI=?="),
+        ("=?base64?literal?=", "=?base64?PT9iYXNlNjQ/bGl0ZXJhbD89?="),
+    ])
+    def test_spec_examples_encode_verbatim(self, value, expected):
+        """Every worked example from the specification encodes exactly."""
+        assert encode_header_value(value) == expected
+
+    @pytest.mark.parametrize("value", [
+        "us-west1",
+        "Hello, 世界",
+        " padded ",
+        "line1\nline2",
+        "=?base64?literal?=",
+    ])
+    def test_spec_examples_round_trip(self, value):
+        """Decoding the encoded form recovers the original value."""
+        assert decode_header_value(encode_header_value(value)) == value
+
+    def test_plain_ascii_is_not_encoded(self):
+        """Safe plain ASCII travels verbatim, so no sentinel is added."""
+        assert encode_header_value("us-west1") == "us-west1"
+        assert not looks_like_sentinel(encode_header_value("us-west1"))
+
+    @pytest.mark.parametrize("value", [
+        "us-west1",
+        "a b c",
+        "tab\tseparated",
+        "!#$%&'*+-.^_`|~",
+        "",
+        "~",
+        "!",
+    ])
+    def test_safe_values(self, value):
+        """Tab, space and printable ASCII 0x21-0x7E are safe."""
+        assert is_safe_plain_ascii(value) is True
+
+    @pytest.mark.parametrize("value,why", [
+        ("Hello, 世界", "non-ascii"),
+        ("café", "non-ascii"),
+        ("line1\nline2", "control char LF"),
+        ("a\rb", "control char CR"),
+        ("a\x00b", "control char NUL"),
+        ("a\x7fb", "DEL is not printable"),
+        (" padded ", "leading and trailing whitespace"),
+        (" leading", "leading whitespace"),
+        ("trailing ", "trailing whitespace"),
+        ("\tleading tab", "leading tab"),
+        ("=?base64?literal?=", "collides with the sentinel"),
+    ])
+    def test_unsafe_values_are_encoded(self, value, why):
+        """Anything not safe plain ASCII gets the sentinel."""
+        assert is_safe_plain_ascii(value) is False, why
+        encoded = encode_header_value(value)
+        assert encoded.startswith(SENTINEL_PREFIX)
+        assert encoded.endswith(SENTINEL_SUFFIX)
+        assert decode_header_value(encoded) == value
+
+    def test_sentinel_markers_are_case_sensitive(self):
+        """Uppercase markers are not a sentinel and decode to themselves."""
+        assert looks_like_sentinel("=?BASE64?dXMtd2VzdDE=?=") is False
+        assert decode_header_value("=?BASE64?dXMtd2VzdDE=?=") == "=?BASE64?dXMtd2VzdDE=?="
+        assert looks_like_sentinel("=?Base64?dXMtd2VzdDE=?=") is False
+
+    def test_markers_may_not_overlap(self):
+        """A string too short to hold both markers is not a sentinel."""
+        assert looks_like_sentinel("=?base64?=") is False
+        assert decode_header_value("=?base64?=") == "=?base64?="
+
+    def test_partial_markers_are_not_sentinels(self):
+        """Both markers must be present."""
+        assert looks_like_sentinel("=?base64?dXMtd2VzdDE=") is False
+        assert looks_like_sentinel("dXMtd2VzdDE=?=") is False
+
+    def test_plain_value_decodes_to_itself(self):
+        """Values without a sentinel pass through untouched."""
+        assert decode_header_value("us-west1") == "us-west1"
+
+    def test_empty_payload_decodes_to_empty_string(self):
+        """An empty base64 payload is legal and yields the empty string."""
+        assert decode_header_value("=?base64??=") == ""
+
+    @pytest.mark.parametrize("malformed", [
+        "=?base64?not valid base64!?=",
+        "=?base64?A?=",
+        "=?base64?////?=",
+    ])
+    def test_malformed_sentinel_degrades_to_raw_value(self, malformed):
+        """A bad payload is returned verbatim rather than raising."""
+        assert decode_header_value(malformed) == malformed
+
+    def test_non_string_is_not_a_sentinel(self):
+        """Defensive: non-string input never looks like a sentinel."""
+        assert looks_like_sentinel(None) is False
+        assert looks_like_sentinel(42) is False
+        assert is_safe_plain_ascii(42) is False
+
+
+# ---------------------------------------------------------------------------
+# (B) Header / body validation
+# ---------------------------------------------------------------------------
+
+def _body(method="tools/call", name="execute_query", arguments=None, protocol_version=None):
+    """Build a JSON-RPC request body for validation tests."""
+    params = {}
+    if name is not None:
+        params["name"] = name
+    if arguments is not None:
+        params["arguments"] = arguments
+    if protocol_version is not None:
+        params["_meta"] = {META_PROTOCOL_VERSION: protocol_version}
+    return {"jsonrpc": "2.0", "id": 1, "method": method, "params": params}
+
+
+class TestStrictOptIn:
+    """Strict validation is opt-in and off by default."""
+
+    def test_default_is_off_and_is_a_no_op(self):
+        """With no flag, even a blatant mismatch produces no errors."""
+        errors = validate_request_headers(
+            {"Mcp-Method": "resources/read"},
+            _body(method="tools/call"),
+        )
+        assert errors == []
+
+    def test_legacy_client_sending_no_headers_is_accepted(self):
+        """A 2025-11-25 client sends no Mcp-* headers at all."""
+        assert validate_request_headers({}, _body()) == []
+
+    def test_strict_flag_enables_enforcement(self):
+        """The same mismatch is reported once strict=True is passed."""
+        errors = validate_request_headers(
+            {"Mcp-Method": "resources/read", "Mcp-Name": "execute_query"},
+            _body(method="tools/call"),
+            strict=True,
+        )
+        assert _reasons(errors) == ["mismatch"]
+        assert errors[0].header == HEADER_MCP_METHOD
+
+    def test_env_helper_defaults_off(self, monkeypatch):
+        """PROMETHEUS_MCP_STRICT_HEADERS defaults to off."""
+        monkeypatch.delenv("PROMETHEUS_MCP_STRICT_HEADERS", raising=False)
+        assert strict_headers_enabled() is False
+
+    @pytest.mark.parametrize("raw,expected", [
+        ("true", True),
+        ("True", True),
+        ("1", True),
+        ("yes", True),
+        ("false", False),
+        ("no", False),
+        ("", False),
+    ])
+    def test_env_helper_parses_switch(self, monkeypatch, raw, expected):
+        """The env switch follows the repo's boolean parsing convention."""
+        monkeypatch.setenv("PROMETHEUS_MCP_STRICT_HEADERS", raw)
+        assert strict_headers_enabled() is expected
+
+    def test_non_mapping_body_is_ignored(self):
+        """Defensive: a body that is not a mapping yields no errors."""
+        assert validate_request_headers({"Mcp-Method": "x"}, None, strict=True) == []
+
+    @pytest.mark.parametrize("headers", [None, {}])
+    def test_absent_headers_mapping_is_tolerated(self, headers):
+        """No Mcp-* headers at all is the legacy case and must be accepted.
+
+        Regression: treating an absent header as a mismatch made every Mcp-*
+        header mandatory, which rejected every shipping MCP client -- including
+        the initialize handshake -- the moment strict mode was switched on.
+        """
+        assert validate_request_headers(headers, _body(), strict=True) == []
+
+    def test_initialize_without_mcp_headers_is_accepted(self):
+        """Regression: strict mode must never lock out the handshake."""
+        body = {
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "initialize",
+            "params": {"protocolVersion": "2025-11-25", "capabilities": {}},
+        }
+        headers = {
+            "accept": "application/json, text/event-stream",
+            "content-type": "application/json",
+        }
+        assert validate_request_headers(headers, body, strict=True) == []
+
+    def test_transport_protocol_version_header_alone_is_accepted(self):
+        """MCP-Protocol-Version is a mandated transport header, not a body mirror.
+
+        Regression: a 2025-11-25 client sends it on every post-initialize
+        request and puts nothing in _meta, which was reported as
+        ``unexpected_header`` and rejected the request with -32020.
+        """
+        headers = {
+            "mcp-protocol-version": "2025-11-25",
+            "mcp-session-id": "abc",
+            "content-type": "application/json",
+        }
+        body = {"method": "tools/list", "params": {}}
+        assert validate_request_headers(headers, body, strict=True) == []
+
+    def test_a_2026_client_may_declare_2026_while_the_transport_says_2025(self):
+        """The SDK transport rejects MCP-Protocol-Version: 2026-07-28 outright.
+
+        A 2026-07-28 client therefore has to send the transport-negotiated
+        revision in the header while declaring 2026-07-28 in _meta. Comparing
+        the two would make strict mode unsatisfiable for every client alive.
+        """
+        headers = {"mcp-protocol-version": "2025-11-25", "mcp-method": "tools/list"}
+        body = {
+            "method": "tools/list",
+            "params": {"_meta": {META_PROTOCOL_VERSION: "2026-07-28"}},
+        }
+        assert validate_request_headers(headers, body, strict=True) == []
+
+
+class TestNumericCoercionGuards:
+    """Guards inside the numeric comparison helper."""
+
+    def test_bool_is_never_treated_as_a_number(self):
+        """bool subclasses int, so it must be rejected before float()."""
+        from prometheus_mcp_server.spec2026.headers import _parse_number
+
+        assert _parse_number(True) is None
+        assert _parse_number(False) is None
+        assert _parse_number(1) == 1.0
+
+    def test_non_scalar_body_value_falls_back_to_string_compare(self):
+        """A list argument cannot be parsed numerically and must not raise."""
+        annotation = HeaderAnnotation(token="Limit", path=("limit",), type_name="integer")
+        errors = validate_request_headers(
+            {
+                "Mcp-Method": "tools/call",
+                "Mcp-Name": "execute_query",
+                "Mcp-Param-Limit": "42",
+            },
+            _body(arguments={"limit": [42]}),
+            strict=True,
+            header_annotations=[annotation],
+        )
+        assert _reasons(errors) == ["mismatch"]
+
+
+class TestMcpMethodHeader:
+    """Mcp-Method vs the body method."""
+
+    def test_matching_method_passes(self):
+        errors = validate_request_headers(
+            {"Mcp-Method": "tools/call", "Mcp-Name": "execute_query"},
+            _body(),
+            strict=True,
+        )
+        assert errors == []
+
+    def test_mismatched_method_is_rejected(self):
+        errors = validate_request_headers(
+            {"Mcp-Method": "tools/list", "Mcp-Name": "execute_query"},
+            _body(method="tools/call"),
+            strict=True,
+        )
+        assert _reasons(errors) == ["mismatch"]
+        assert errors[0].header_value == "tools/list"
+        assert errors[0].body_value == "tools/call"
+
+    def test_missing_header_when_value_in_body_is_accepted(self):
+        """An omitted Mcp-Method is legal: the headers are optional hints.
+
+        Regression: this used to be reported as ``missing_header``, which made
+        Mcp-Method mandatory on every request (every JSON-RPC body has a
+        method) and locked out every client that does not send it.
+        """
+        assert validate_request_headers({"Mcp-Name": "execute_query"}, _body(), strict=True) == []
+
+    def test_encoded_header_value_is_decoded_before_comparison(self):
+        """The server decodes the sentinel before comparing."""
+        errors = validate_request_headers(
+            {
+                "Mcp-Method": encode_header_value("tools/call"),
+                "Mcp-Name": encode_header_value("Hello, 世界"),
+            },
+            _body(name="Hello, 世界"),
+            strict=True,
+        )
+        assert errors == []
+
+
+class TestHeaderNameAndValueCasing:
+    """Header names are case-insensitive; values are case-sensitive."""
+
+    @pytest.mark.parametrize("header_name", [
+        "Mcp-Method",
+        "mcp-method",
+        "MCP-METHOD",
+        "mCp-MeThOd",
+    ])
+    def test_header_names_compare_case_insensitively(self, header_name):
+        errors = validate_request_headers(
+            {header_name: "tools/call", "mcp-name": "execute_query"},
+            _body(),
+            strict=True,
+        )
+        assert errors == []
+
+    def test_header_values_compare_case_sensitively(self):
+        """A value differing only in case is a mismatch."""
+        errors = validate_request_headers(
+            {"Mcp-Method": "Tools/Call", "Mcp-Name": "execute_query"},
+            _body(method="tools/call"),
+            strict=True,
+        )
+        assert _reasons(errors) == ["mismatch"]
+
+    def test_name_value_case_matters(self):
+        errors = validate_request_headers(
+            {"Mcp-Method": "tools/call", "Mcp-Name": "Execute_Query"},
+            _body(name="execute_query"),
+            strict=True,
+        )
+        assert _reasons(errors) == ["mismatch"]
+        assert errors[0].header == HEADER_MCP_NAME
+
+
+class TestMcpNameHeader:
+    """Mcp-Name vs params.name or params.uri."""
+
+    def test_matches_params_name(self):
+        errors = validate_request_headers(
+            {"Mcp-Method": "tools/call", "Mcp-Name": "execute_query"},
+            _body(),
+            strict=True,
+        )
+        assert errors == []
+
+    def test_matches_params_uri_when_name_absent(self):
+        """resources/read carries a uri rather than a name."""
+        body = {
+            "method": "resources/read",
+            "params": {"uri": "prometheus://metrics"},
+        }
+        errors = validate_request_headers(
+            {"Mcp-Method": "resources/read", "Mcp-Name": "prometheus://metrics"},
+            body,
+            strict=True,
+        )
+        assert errors == []
+
+    def test_uri_mismatch_is_rejected(self):
+        body = {"method": "resources/read", "params": {"uri": "prometheus://metrics"}}
+        errors = validate_request_headers(
+            {"Mcp-Method": "resources/read", "Mcp-Name": "prometheus://targets"},
+            body,
+            strict=True,
+        )
+        assert _reasons(errors) == ["mismatch"]
+
+    def test_absent_name_and_uri_requires_omitted_header(self):
+        """tools/list has neither; omitting the header is not an error."""
+        body = {"method": "tools/list", "params": {}}
+        errors = validate_request_headers(
+            {"Mcp-Method": "tools/list"},
+            body,
+            strict=True,
+        )
+        assert errors == []
+
+    def test_header_sent_without_body_value_is_rejected(self):
+        """The header must be omitted when the body carries no value."""
+        body = {"method": "tools/list", "params": {}}
+        errors = validate_request_headers(
+            {"Mcp-Method": "tools/list", "Mcp-Name": "execute_query"},
+            body,
+            strict=True,
+        )
+        assert _reasons(errors) == ["unexpected_header"]
+        assert errors[0].header == HEADER_MCP_NAME
+
+    def test_null_name_falls_back_to_uri(self):
+        body = {
+            "method": "resources/read",
+            "params": {"name": None, "uri": "prometheus://metrics"},
+        }
+        errors = validate_request_headers(
+            {"Mcp-Method": "resources/read", "Mcp-Name": "prometheus://metrics"},
+            body,
+            strict=True,
+        )
+        assert errors == []
+
+    def test_missing_params_entirely_is_tolerated(self):
+        body = {"method": "ping"}
+        errors = validate_request_headers({"Mcp-Method": "ping"}, body, strict=True)
+        assert errors == []
+
+
+class TestProtocolVersionHeader:
+    """MCP-Protocol-Version vs the _meta protocol version."""
+
+    def test_matching_version_passes(self):
+        errors = validate_request_headers(
+            {
+                "Mcp-Method": "tools/call",
+                "Mcp-Name": "execute_query",
+                "MCP-Protocol-Version": "2026-07-28",
+            },
+            _body(protocol_version="2026-07-28"),
+            strict=True,
+        )
+        assert errors == []
+
+    def test_mismatched_version_is_rejected(self):
+        """A declared revision the transport *can* carry is still compared."""
+        errors = validate_request_headers(
+            {
+                "Mcp-Method": "tools/call",
+                "Mcp-Name": "execute_query",
+                "MCP-Protocol-Version": "2025-06-18",
+            },
+            _body(protocol_version="2025-11-25"),
+            strict=True,
+        )
+        assert _reasons(errors) == ["mismatch"]
+        assert errors[0].header == HEADER_MCP_PROTOCOL_VERSION
+
+    def test_absent_version_in_body_needs_no_header(self):
+        """Legacy requests carry no _meta protocolVersion; that is fine."""
+        errors = validate_request_headers(
+            {"Mcp-Method": "tools/call", "Mcp-Name": "execute_query"},
+            _body(),
+            strict=True,
+        )
+        assert errors == []
+
+    def test_top_level_meta_is_also_accepted(self):
+        """Defensive: _meta at the envelope root is read as a fallback."""
+        body = {
+            "method": "tools/list",
+            "params": {},
+            "_meta": {META_PROTOCOL_VERSION: "2026-07-28"},
+        }
+        errors = validate_request_headers(
+            {"Mcp-Method": "tools/list", "MCP-Protocol-Version": "2026-07-28"},
+            body,
+            strict=True,
+        )
+        assert errors == []
+
+    def test_missing_header_when_version_in_body_is_accepted(self):
+        """Not sending the transport header is never this validator's business."""
+        errors = validate_request_headers(
+            {"Mcp-Method": "tools/call", "Mcp-Name": "execute_query"},
+            _body(protocol_version="2025-11-25"),
+            strict=True,
+        )
+        assert errors == []
+
+
+class TestParamHeaderValidation:
+    """Mcp-Param-{Name} vs the annotated argument value."""
+
+    REGION = HeaderAnnotation(token="Region", path=("region",), type_name="string")
+    LIMIT = HeaderAnnotation(token="Limit", path=("limit",), type_name="integer")
+    VERBOSE = HeaderAnnotation(token="Verbose", path=("verbose",), type_name="boolean")
+
+    def test_header_name_is_prefixed(self):
+        assert self.REGION.header_name == f"{PARAM_HEADER_PREFIX}Region"
+        assert self.REGION.header_name == "Mcp-Param-Region"
+
+    def test_matching_string_param_passes(self):
+        errors = validate_request_headers(
+            {
+                "Mcp-Method": "tools/call",
+                "Mcp-Name": "execute_query",
+                "Mcp-Param-Region": "us-west1",
+            },
+            _body(arguments={"region": "us-west1"}),
+            strict=True,
+            header_annotations=[self.REGION],
+        )
+        assert errors == []
+
+    def test_mismatched_string_param_is_rejected(self):
+        errors = validate_request_headers(
+            {
+                "Mcp-Method": "tools/call",
+                "Mcp-Name": "execute_query",
+                "Mcp-Param-Region": "eu-central1",
+            },
+            _body(arguments={"region": "us-west1"}),
+            strict=True,
+            header_annotations=[self.REGION],
+        )
+        assert _reasons(errors) == ["mismatch"]
+        assert errors[0].header == "Mcp-Param-Region"
+
+    @pytest.mark.parametrize("header_value,body_value", [
+        ("42", 42),
+        ("42.0", 42),
+        ("42", 42.0),
+        ("42.0", 42.0),
+        ("42.00", 42),
+        ("-7", -7),
+        ("0", 0),
+    ])
+    def test_integer_params_compare_numerically(self, header_value, body_value):
+        """42.0 == 42: integers compare as numbers, not as strings."""
+        errors = validate_request_headers(
+            {
+                "Mcp-Method": "tools/call",
+                "Mcp-Name": "execute_query",
+                "Mcp-Param-Limit": header_value,
+            },
+            _body(arguments={"limit": body_value}),
+            strict=True,
+            header_annotations=[self.LIMIT],
+        )
+        assert errors == [], f"{header_value!r} should equal {body_value!r} numerically"
+
+    @pytest.mark.parametrize("header_value,body_value", [
+        ("43", 42),
+        ("42.5", 42),
+        ("4 2", 42),
+        ("", 42),
+        ("forty-two", 42),
+    ])
+    def test_numerically_different_values_are_rejected(self, header_value, body_value):
+        errors = validate_request_headers(
+            {
+                "Mcp-Method": "tools/call",
+                "Mcp-Name": "execute_query",
+                "Mcp-Param-Limit": header_value,
+            },
+            _body(arguments={"limit": body_value}),
+            strict=True,
+            header_annotations=[self.LIMIT],
+        )
+        assert _reasons(errors) == ["mismatch"]
+
+    @pytest.mark.parametrize("body_value,header_value", [
+        (True, "true"),
+        (False, "false"),
+    ])
+    def test_boolean_params_use_json_casing(self, body_value, header_value):
+        errors = validate_request_headers(
+            {
+                "Mcp-Method": "tools/call",
+                "Mcp-Name": "execute_query",
+                "Mcp-Param-Verbose": header_value,
+            },
+            _body(arguments={"verbose": body_value}),
+            strict=True,
+            header_annotations=[self.VERBOSE],
+        )
+        assert errors == []
+
+    def test_boolean_header_casing_is_significant(self):
+        """Header values are case-sensitive, so 'True' does not match true."""
+        errors = validate_request_headers(
+            {
+                "Mcp-Method": "tools/call",
+                "Mcp-Name": "execute_query",
+                "Mcp-Param-Verbose": "True",
+            },
+            _body(arguments={"verbose": True}),
+            strict=True,
+            header_annotations=[self.VERBOSE],
+        )
+        assert _reasons(errors) == ["mismatch"]
+
+    def test_boolean_true_does_not_match_numeric_one(self):
+        """bool must not be coerced into the numeric comparison path."""
+        errors = validate_request_headers(
+            {
+                "Mcp-Method": "tools/call",
+                "Mcp-Name": "execute_query",
+                "Mcp-Param-Verbose": "1",
+            },
+            _body(arguments={"verbose": True}),
+            strict=True,
+            header_annotations=[self.VERBOSE],
+        )
+        assert _reasons(errors) == ["mismatch"]
+
+    def test_missing_param_header_is_accepted_when_argument_present(self):
+        """Regression: a client passing an annotated argument as a plain
+        argument must not be forced to mirror it into a header as well."""
+        errors = validate_request_headers(
+            {"Mcp-Method": "tools/call", "Mcp-Name": "execute_query"},
+            _body(arguments={"region": "us-west1"}),
+            strict=True,
+            header_annotations=[self.REGION],
+        )
+        assert errors == []
+
+    @pytest.mark.parametrize("arguments", [
+        {},
+        {"region": None},
+        {"other": "value"},
+        None,
+    ])
+    def test_absent_or_null_argument_needs_no_header(self, arguments):
+        """Absent/null in the body => header omitted, and that is NOT an error."""
+        errors = validate_request_headers(
+            {"Mcp-Method": "tools/call", "Mcp-Name": "execute_query"},
+            _body(arguments=arguments),
+            strict=True,
+            header_annotations=[self.REGION],
+        )
+        assert errors == []
+
+    def test_param_header_sent_without_argument_is_rejected(self):
+        errors = validate_request_headers(
+            {
+                "Mcp-Method": "tools/call",
+                "Mcp-Name": "execute_query",
+                "Mcp-Param-Region": "us-west1",
+            },
+            _body(arguments={}),
+            strict=True,
+            header_annotations=[self.REGION],
+        )
+        assert _reasons(errors) == ["unexpected_header"]
+
+    def test_nested_argument_path_is_honoured(self):
+        nested = HeaderAnnotation(
+            token="Region", path=("filters", "region"), type_name="string",
+        )
+        errors = validate_request_headers(
+            {
+                "Mcp-Method": "tools/call",
+                "Mcp-Name": "execute_query",
+                "Mcp-Param-Region": "us-west1",
+            },
+            _body(arguments={"filters": {"region": "us-west1"}}),
+            strict=True,
+            header_annotations=[nested],
+        )
+        assert errors == []
+
+    def test_encoded_param_value_is_decoded(self):
+        errors = validate_request_headers(
+            {
+                "Mcp-Method": "tools/call",
+                "Mcp-Name": "execute_query",
+                "Mcp-Param-Region": encode_header_value(" padded "),
+            },
+            _body(arguments={"region": " padded "}),
+            strict=True,
+            header_annotations=[self.REGION],
+        )
+        assert errors == []
+
+    def test_multiple_mismatches_are_all_reported(self):
+        errors = validate_request_headers(
+            {
+                "Mcp-Method": "tools/list",
+                "Mcp-Name": "wrong_tool",
+                "Mcp-Param-Region": "eu-central1",
+            },
+            _body(arguments={"region": "us-west1"}),
+            strict=True,
+            header_annotations=[self.REGION],
+        )
+        assert len(errors) == 3
+        assert set(_reasons(errors)) == {"mismatch"}
+
+
+class TestHeaderMismatchError:
+    """The JSON-RPC error object rendered from findings."""
+
+    def test_uses_code_minus_32020(self):
+        errors = validate_request_headers(
+            {"Mcp-Method": "tools/list", "Mcp-Name": "execute_query"},
+            _body(method="tools/call"),
+            strict=True,
+        )
+        payload = header_mismatch_error(errors)
+        assert payload["code"] == -32020
+        assert payload["code"] == HEADER_MISMATCH
+        assert "HeaderMismatch" in payload["message"]
+
+    def test_data_describes_each_mismatch(self):
+        errors = validate_request_headers(
+            {"Mcp-Method": "tools/list", "Mcp-Name": "execute_query"},
+            _body(method="tools/call"),
+            strict=True,
+        )
+        mismatches = header_mismatch_error(errors)["data"]["mismatches"]
+        assert len(mismatches) == 1
+        assert mismatches[0]["header"] == HEADER_MCP_METHOD
+        assert mismatches[0]["headerValue"] == "tools/list"
+        assert mismatches[0]["bodyValue"] == "tools/call"
+        assert mismatches[0]["reason"] == "mismatch"
+
+    def test_json_serialisable(self):
+        import json
+
+        errors = validate_request_headers(
+            {"Mcp-Method": "tools/list"},
+            _body(method="tools/call", name=None),
+            strict=True,
+        )
+        assert json.loads(json.dumps(header_mismatch_error(errors)))["code"] == -32020
+
+
+# ---------------------------------------------------------------------------
+# (C) x-mcp-header inputSchema validation
+# ---------------------------------------------------------------------------
+
+def _schema(properties, **extra):
+    """Build an object schema with the given properties."""
+    schema = {"type": "object", "properties": properties}
+    schema.update(extra)
+    return schema
+
+
+class TestValidAnnotations:
+    """Schemas that satisfy every constraint."""
+
+    def test_primitive_types_are_accepted(self):
+        schema = _schema({
+            "region": {"type": "string", ANNOTATION_KEY: "Region"},
+            "limit": {"type": "integer", ANNOTATION_KEY: "Limit"},
+            "verbose": {"type": "boolean", ANNOTATION_KEY: "Verbose"},
+        })
+        assert validate_header_annotations(schema) == []
+        annotations = collect_header_annotations(schema)
+        assert [a.token for a in annotations] == ["Region", "Limit", "Verbose"]
+        assert [a.type_name for a in annotations] == ["string", "integer", "boolean"]
+
+    def test_nested_properties_chain_is_reachable(self):
+        schema = _schema({
+            "filters": _schema({"region": {"type": "string", ANNOTATION_KEY: "Region"}}),
+        })
+        assert validate_header_annotations(schema) == []
+        annotation = collect_header_annotations(schema)[0]
+        assert annotation.path == ("filters", "region")
+        assert annotation.header_name == "Mcp-Param-Region"
+
+    def test_unannotated_schema_yields_nothing(self):
+        schema = _schema({"query": {"type": "string"}})
+        assert validate_header_annotations(schema) == []
+        assert collect_header_annotations(schema) == []
+
+    @pytest.mark.parametrize("token", [
+        "Region", "region", "X-Trace", "a", "0", "abc123",
+        "!#$%&'*+-.^_`|~",
+    ])
+    def test_tchar_tokens_are_accepted(self, token):
+        schema = _schema({"p": {"type": "string", ANNOTATION_KEY: token}})
+        assert validate_header_annotations(schema) == []
+
+    def test_property_named_items_is_still_reachable(self):
+        """A property literally named 'items' is not the 'items' keyword."""
+        schema = _schema({"items": {"type": "string", ANNOTATION_KEY: "Items"}})
+        assert validate_header_annotations(schema) == []
+        assert collect_header_annotations(schema)[0].path == ("items",)
+
+    @pytest.mark.parametrize("bad", [None, "not a schema", 42, []])
+    def test_non_dict_schema_is_tolerated(self, bad):
+        """Defensive: a malformed inputSchema must not raise."""
+        assert validate_header_annotations(bad) == []
+        assert collect_header_annotations(bad) == []
+
+
+class TestAnnotationRejections:
+    """At least one rejection case per documented constraint."""
+
+    def test_empty_token_is_rejected(self):
+        schema = _schema({"region": {"type": "string", ANNOTATION_KEY: ""}})
+        assert _codes(validate_header_annotations(schema)) == ["empty"]
+        assert collect_header_annotations(schema) == []
+
+    def test_non_string_token_is_rejected(self):
+        schema = _schema({"region": {"type": "string", ANNOTATION_KEY: 42}})
+        assert _codes(validate_header_annotations(schema)) == ["not_a_string"]
+
+    @pytest.mark.parametrize("token", ["Reg\rion", "Reg\nion", "Region\r\n"])
+    def test_crlf_in_token_is_rejected(self, token):
+        """Header injection via CR/LF must be refused."""
+        schema = _schema({"region": {"type": "string", ANNOTATION_KEY: token}})
+        assert _codes(validate_header_annotations(schema)) == ["crlf"]
+
+    @pytest.mark.parametrize("token", [
+        "has space",
+        "colon:name",
+        "quote\"name",
+        "paren(name)",
+        "comma,name",
+        "slash/name",
+        "at@name",
+        "semi;name",
+        "brace{name}",
+        "back\\slash",
+        "square[name]",
+        "equals=name",
+        "question?name",
+        "less<name>",
+        "Région",
+        "\ttab",
+    ])
+    def test_non_tchar_token_is_rejected(self, token):
+        """RFC 9110 tchar syntax excludes separators and non-ASCII."""
+        schema = _schema({"region": {"type": "string", ANNOTATION_KEY: token}})
+        assert _codes(validate_header_annotations(schema)) == ["invalid_token"]
+
+    def test_case_insensitive_duplicates_are_rejected(self):
+        schema = _schema({
+            "region": {"type": "string", ANNOTATION_KEY: "Region"},
+            "region2": {"type": "string", ANNOTATION_KEY: "region"},
+        })
+        errors = validate_header_annotations(schema)
+        assert _codes(errors) == ["duplicate"]
+        assert errors[0].path == ("region2",)
+        # Only the first occurrence survives.
+        assert [a.path for a in collect_header_annotations(schema)] == [("region",)]
+
+    def test_exact_duplicates_are_rejected(self):
+        schema = _schema({
+            "a": {"type": "string", ANNOTATION_KEY: "Region"},
+            "b": {"type": "string", ANNOTATION_KEY: "Region"},
+        })
+        assert _codes(validate_header_annotations(schema)) == ["duplicate"]
+
+    def test_duplicate_across_nesting_levels_is_rejected(self):
+        schema = _schema({
+            "region": {"type": "string", ANNOTATION_KEY: "Region"},
+            "filters": _schema({"region": {"type": "string", ANNOTATION_KEY: "REGION"}}),
+        })
+        assert _codes(validate_header_annotations(schema)) == ["duplicate"]
+
+    def test_number_type_is_not_permitted(self):
+        """'number' is explicitly excluded even though it is primitive."""
+        schema = _schema({"ratio": {"type": "number", ANNOTATION_KEY: "Ratio"}})
+        errors = validate_header_annotations(schema)
+        assert _codes(errors) == ["invalid_type"]
+        assert "number" in errors[0].message
+        assert collect_header_annotations(schema) == []
+
+    @pytest.mark.parametrize("type_value", [
+        "array",
+        "object",
+        "null",
+        None,
+        ["string", "null"],
+        "STRING",
+    ])
+    def test_non_primitive_types_are_rejected(self, type_value):
+        prop = {ANNOTATION_KEY: "Region"}
+        if type_value is not None:
+            prop["type"] = type_value
+        schema = _schema({"region": prop})
+        assert _codes(validate_header_annotations(schema)) == ["invalid_type"]
+
+    def test_annotation_inside_items_is_unreachable(self):
+        schema = _schema({
+            "regions": {
+                "type": "array",
+                "items": {"type": "string", ANNOTATION_KEY: "Region"},
+            },
+        })
+        assert _codes(validate_header_annotations(schema)) == ["unreachable"]
+        assert collect_header_annotations(schema) == []
+
+    @pytest.mark.parametrize("keyword", ["oneOf", "anyOf", "allOf"])
+    def test_annotation_inside_combinators_is_unreachable(self, keyword):
+        schema = _schema({}, **{
+            keyword: [_schema({"region": {"type": "string", ANNOTATION_KEY: "Region"}})],
+        })
+        assert "unreachable" in _codes(validate_header_annotations(schema))
+        assert collect_header_annotations(schema) == []
+
+    def test_annotation_inside_not_is_unreachable(self):
+        schema = _schema({}, **{
+            "not": _schema({"region": {"type": "string", ANNOTATION_KEY: "Region"}}),
+        })
+        assert "unreachable" in _codes(validate_header_annotations(schema))
+
+    @pytest.mark.parametrize("keyword", ["if", "then", "else"])
+    def test_annotation_inside_conditionals_is_unreachable(self, keyword):
+        schema = _schema({}, **{
+            keyword: _schema({"region": {"type": "string", ANNOTATION_KEY: "Region"}}),
+        })
+        assert "unreachable" in _codes(validate_header_annotations(schema))
+
+    def test_annotation_behind_ref_is_unreachable(self):
+        """$ref is never followed, so $defs content is not reachable."""
+        schema = _schema(
+            {"filters": {"$ref": "#/$defs/Filters"}},
+            **{"$defs": {
+                "Filters": _schema({"region": {"type": "string", ANNOTATION_KEY: "Region"}}),
+            }},
+        )
+        assert "unreachable" in _codes(validate_header_annotations(schema))
+        assert collect_header_annotations(schema) == []
+
+    def test_annotation_on_schema_root_is_rejected(self):
+        schema = _schema({"region": {"type": "string"}}, **{ANNOTATION_KEY: "Region"})
+        errors = validate_header_annotations(schema)
+        assert _codes(errors) == ["not_a_property"]
+        assert errors[0].path == ()
+
+    def test_error_is_serialisable(self):
+        schema = _schema({"region": {"type": "number", ANNOTATION_KEY: "Region"}})
+        payload = validate_header_annotations(schema)[0].to_dict()
+        assert payload["code"] == "invalid_type"
+        assert payload["path"] == ["region"]
+        assert payload["token"] == "Region"
+
+    def test_valid_and_invalid_annotations_coexist(self):
+        """A broken annotation does not discard the good ones."""
+        schema = _schema({
+            "region": {"type": "string", ANNOTATION_KEY: "Region"},
+            "ratio": {"type": "number", ANNOTATION_KEY: "Ratio"},
+        })
+        assert _codes(validate_header_annotations(schema)) == ["invalid_type"]
+        assert [a.token for a in collect_header_annotations(schema)] == ["Region"]
+
+    def test_self_referential_schema_terminates(self):
+        """Defensive: a cyclic Python dict must not recurse forever."""
+        schema = _schema({"region": {"type": "string", ANNOTATION_KEY: "Region"}})
+        schema["properties"]["self"] = schema
+        assert validate_header_annotations(schema) == []
+        assert [a.token for a in collect_header_annotations(schema)] == ["Region"]
+
+    def test_shared_list_node_is_visited_once(self):
+        """Defensive: the same list object reached twice must not loop."""
+        shared = [_schema({"region": {"type": "string", ANNOTATION_KEY: "Region"}})]
+        schema = _schema({}, oneOf=shared, anyOf=shared)
+        assert _codes(validate_header_annotations(schema)) == ["unreachable"]
+
+    @pytest.mark.parametrize("properties", [
+        {"region": "not a schema"},
+        {"region": None},
+        {"region": ["array"]},
+        {1: {"type": "string", ANNOTATION_KEY: "Region"}},
+    ])
+    def test_malformed_property_entries_are_skipped(self, properties):
+        """Defensive: junk inside 'properties' must not raise."""
+        assert collect_header_annotations(_schema(properties)) == []
+
+
+class TestExtractParamHeaders:
+    """Reading annotated values out of tool arguments."""
+
+    def test_reads_value_at_exact_path(self):
+        schema = _schema({
+            "filters": _schema({"region": {"type": "string", ANNOTATION_KEY: "Region"}}),
+        })
+        annotations = collect_header_annotations(schema)
+        headers = extract_param_headers(annotations, {"filters": {"region": "us-west1"}})
+        assert headers == {"Mcp-Param-Region": "us-west1"}
+
+    def test_encodes_unsafe_values(self):
+        schema = _schema({"region": {"type": "string", ANNOTATION_KEY: "Region"}})
+        annotations = collect_header_annotations(schema)
+        headers = extract_param_headers(annotations, {"region": "Hello, 世界"})
+        assert headers == {"Mcp-Param-Region": "=?base64?SGVsbG8sIOS4lueVjA==?="}
+
+    @pytest.mark.parametrize("arguments", [
+        {},
+        {"region": None},
+        {"filters": {}},
+        None,
+        "not a mapping",
+    ])
+    def test_omits_header_when_no_value_present(self, arguments):
+        schema = _schema({"region": {"type": "string", ANNOTATION_KEY: "Region"}})
+        annotations = collect_header_annotations(schema)
+        assert extract_param_headers(annotations, arguments) == {}
+
+    def test_omits_header_when_nested_path_is_absent(self):
+        schema = _schema({
+            "filters": _schema({"region": {"type": "string", ANNOTATION_KEY: "Region"}}),
+        })
+        annotations = collect_header_annotations(schema)
+        assert extract_param_headers(annotations, {"filters": {"other": 1}}) == {}
+        assert extract_param_headers(annotations, {"filters": "scalar"}) == {}
+
+    @pytest.mark.parametrize("value,expected", [
+        (42, "42"),
+        (42.0, "42"),
+        (True, "true"),
+        (False, "false"),
+        (0, "0"),
+    ])
+    def test_formats_primitives_json_style(self, value, expected):
+        annotation = HeaderAnnotation(token="P", path=("p",), type_name="integer")
+        assert extract_param_headers([annotation], {"p": value}) == {"Mcp-Param-P": expected}
+
+    def test_extracted_headers_validate_round_trip(self):
+        """Headers built by the extractor pass strict validation."""
+        schema = _schema({
+            "region": {"type": "string", ANNOTATION_KEY: "Region"},
+            "limit": {"type": "integer", ANNOTATION_KEY: "Limit"},
+            "verbose": {"type": "boolean", ANNOTATION_KEY: "Verbose"},
+        })
+        annotations = collect_header_annotations(schema)
+        arguments = {"region": " padded ", "limit": 42, "verbose": False}
+
+        headers = {"Mcp-Method": "tools/call", "Mcp-Name": "execute_query"}
+        headers.update(extract_param_headers(annotations, arguments))
+
+        errors = validate_request_headers(
+            headers,
+            _body(arguments=arguments),
+            strict=True,
+            header_annotations=annotations,
+        )
+        assert errors == []
+
+    def test_empty_annotation_list_yields_no_headers(self):
+        assert extract_param_headers([], {"region": "us-west1"}) == {}
+
+
+# ---------------------------------------------------------------------------
+# Regressions found by adversarial review
+# ---------------------------------------------------------------------------
+
+class TestNumericComparisonIsJsonOnly:
+    """Numeric header values must parse as JSON numbers, not as Python floats."""
+
+    @pytest.mark.parametrize("header_value", [
+        "4_2",       # PEP 515 underscore separator: float("4_2") == 42.0
+        "４２",       # fullwidth digits: float() accepts Unicode decimals
+        " 42",
+        "42 ",
+        "0x2a",
+        "",
+        "+42",
+        "042",
+        "inf",
+        "nan",
+    ])
+    def test_non_json_numbers_never_match_an_integer_body_value(self, header_value):
+        """Regression: float() accepted values no JSON client could have sent."""
+        from prometheus_mcp_server.spec2026.headers import _values_match
+
+        assert _values_match(header_value, 42, "integer") is False
+
+    @pytest.mark.parametrize("header_value", ["42", "42.0", "4.2e1", "-42"])
+    def test_legal_json_numbers_still_compare_numerically(self, header_value):
+        """Integer params compare numerically, so 42.0 still equals 42."""
+        from prometheus_mcp_server.spec2026.headers import _values_match
+
+        expected = -42 if header_value.startswith("-") else 42
+        assert _values_match(header_value, expected, "integer") is True
+
+    def test_number_is_not_a_permitted_annotation_type(self):
+        """`number` must not sneak into the numeric branch as a declared type."""
+        from prometheus_mcp_server.spec2026.headers import ALLOWED_ANNOTATION_TYPES
+
+        assert "number" not in ALLOWED_ANNOTATION_TYPES
+
+
+class TestResourceUriComparison:
+    """Mcp-Name for resources/read compares URIs, not raw strings."""
+
+    @pytest.mark.parametrize("header_uri,body_uri", [
+        ("http://example.com", "http://example.com/"),
+        ("http://example.com/", "http://example.com"),
+        ("HTTP://Example.COM/metrics", "http://example.com/metrics"),
+        ("prometheus://metrics", "prometheus://metrics"),
+    ])
+    def test_equivalent_uris_are_not_a_mismatch(self, header_uri, body_uri):
+        """Regression: a URI round-tripped through a parser gains a trailing
+        slash and a lowercased host, which was reported as a HeaderMismatch."""
+        errors = validate_request_headers(
+            {"Mcp-Method": "resources/read", "Mcp-Name": header_uri},
+            {"method": "resources/read", "params": {"uri": body_uri}},
+            strict=True,
+        )
+        assert errors == []
+
+    def test_a_genuinely_different_uri_is_still_rejected(self):
+        errors = validate_request_headers(
+            {"Mcp-Method": "resources/read", "Mcp-Name": "http://example.com/a"},
+            {"method": "resources/read", "params": {"uri": "http://example.com/b"}},
+            strict=True,
+        )
+        assert _reasons(errors) == ["mismatch"]
+
+
+class TestSdkClientHeaderSets:
+    """The exact header sets shipping MCP clients send must pass strict mode."""
+
+    @pytest.mark.parametrize("method", ["initialize", "tools/list", "tools/call", "ping"])
+    def test_official_sdk_streamable_http_headers_are_accepted(self, method):
+        """Regression: strict mode rejected every request from every client."""
+        headers = {
+            "accept": "application/json, text/event-stream",
+            "content-type": "application/json",
+            "mcp-session-id": "3f9c1c0e",
+            "mcp-protocol-version": "2025-11-25",
+        }
+        params = {"name": "health_check", "arguments": {}} if method == "tools/call" else {}
+        body = {"jsonrpc": "2.0", "id": 1, "method": method, "params": params}
+
+        assert validate_request_headers(headers, body, strict=True) == []
+
+
+class TestUriNormalisationGuards:
+    """Defensive branches of the URI comparison helper."""
+
+    @pytest.mark.parametrize("value", [None, 42, ["a"]])
+    def test_non_strings_pass_through(self, value):
+        from prometheus_mcp_server.spec2026.headers import _normalize_uri
+
+        assert _normalize_uri(value) is value
+
+    def test_a_relative_reference_is_left_alone(self):
+        """No scheme means there is nothing to normalise."""
+        from prometheus_mcp_server.spec2026.headers import _normalize_uri
+
+        assert _normalize_uri("metrics/up") == "metrics/up"
+
+    def test_an_unparseable_uri_is_left_alone(self):
+        """urlsplit raises on a malformed IPv6 literal; that must not escape."""
+        from prometheus_mcp_server.spec2026.headers import _normalize_uri
+
+        assert _normalize_uri("http://[::1") == "http://[::1"

--- a/tests/test_spec2026_integration.py
+++ b/tests/test_spec2026_integration.py
@@ -1,0 +1,1093 @@
+"""Tests for the MCP 2026-07-28 compatibility layer as wired into server.py."""
+
+import asyncio
+import importlib.util
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastmcp import Client
+from mcp.shared.exceptions import McpError
+
+import prometheus_mcp_server.server as server
+from prometheus_mcp_server.server import (
+    PrometheusConfig,
+    SPEC_2026_STATUS,
+    _current_request_meta,
+    _env_int,
+    _org_id_json_schema,
+    _wrap_negotiation,
+    clear_metrics_cache,
+    config,
+    execute_query,
+    install_negotiation,
+    install_spec_2026,
+    make_prometheus_request,
+    mcp,
+    resolve_org_id,
+    strict_header_asgi_middleware,
+    tool_header_annotations,
+)
+from prometheus_mcp_server.spec2026.asgi import StrictHeaderMiddleware
+from prometheus_mcp_server.spec2026.headers import validate_header_annotations
+from prometheus_mcp_server.spec2026.negotiation import get_current_negotiation
+from prometheus_mcp_server.spec2026.otel import get_trace_headers, set_trace_headers
+
+VALID_TRACEPARENT = "00-" + "a" * 32 + "-" + "b" * 16 + "-01"
+
+
+@pytest.fixture(autouse=True)
+def reset_shared_server_state():
+    """Reset the metrics cache and re-arm the envelope on the shared server.
+
+    Other modules exercise install/uninstall against the same FastMCP
+    singleton, so this module re-installs the envelope with server.py's own
+    settings rather than assuming import-time state survived, and stays correct
+    no matter which order pytest happens to collect the files in.
+    install_envelope replaces rather than nests, so this is safe to run before
+    every test.
+    """
+    clear_metrics_cache()
+    server.install_envelope(
+        mcp,
+        server_name=server.mcp_name,
+        server_version=server.SERVER_VERSION,
+        ttl_ms=config.cache_ttl_ms,
+        cache_scope=config.cache_scope,
+    )
+    yield
+    clear_metrics_cache()
+
+
+@pytest.fixture
+def restore_config():
+    """Restore every config field this module mutates."""
+    saved = {
+        field: getattr(config, field)
+        for field in (
+            "url",
+            "org_id",
+            "custom_headers",
+            "strict_headers",
+            "cache_scope",
+            "cache_ttl_ms",
+            "allow_org_id_override",
+        )
+    }
+    yield config
+    for field, value in saved.items():
+        setattr(config, field, value)
+
+
+@pytest.fixture
+def mock_response():
+    """Build a successful Prometheus HTTP response."""
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.json.return_value = {
+        "status": "success",
+        "data": {"resultType": "vector", "result": []},
+    }
+    return response
+
+
+# ---------------------------------------------------------------------------
+# F9 configuration surface
+# ---------------------------------------------------------------------------
+
+def test_config_exposes_the_spec_2026_fields_with_documented_defaults():
+    """The four new env-backed fields default to the documented values."""
+    defaults = PrometheusConfig(url="http://prometheus:9090")
+
+    assert defaults.spec_2026_enabled is True
+    assert defaults.cache_ttl_ms == 300000
+    assert defaults.cache_scope == "public"
+    assert defaults.strict_headers is False
+    assert defaults.allow_org_id_override is False
+
+
+@pytest.mark.parametrize("raw", ["300000.5", "5m", "abc", "", "300000ms"])
+def test_a_malformed_cache_ttl_env_var_never_crashes_the_import(raw, monkeypatch):
+    """Regression: `int(os.environ[...])` at module scope took the process down.
+
+    A newly introduced, entirely optional env var must degrade to the documented
+    default with a logged warning, never to an unhandled ValueError before any
+    of the layer's defensive machinery has had a chance to run.
+    """
+    monkeypatch.setenv("PROMETHEUS_MCP_CACHE_TTL_MS", raw)
+    assert _env_int("PROMETHEUS_MCP_CACHE_TTL_MS", 300000) == 300000
+
+
+def test_a_valid_cache_ttl_env_var_is_still_honoured(monkeypatch):
+    """The defensive parse must not swallow legitimate configuration."""
+    monkeypatch.setenv("PROMETHEUS_MCP_CACHE_TTL_MS", "60000")
+    assert _env_int("PROMETHEUS_MCP_CACHE_TTL_MS", 300000) == 60000
+
+
+def test_a_malformed_cache_ttl_leaves_the_module_importable(monkeypatch):
+    """End to end: importing server.py with a bad TTL must not raise."""
+    with patch.dict(os.environ, {"PROMETHEUS_MCP_CACHE_TTL_MS": "5m"}):
+        spec = importlib.util.spec_from_file_location(
+            "prometheus_mcp_server._server_bad_ttl", server.__file__
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+    assert module.config.cache_ttl_ms == 300000
+
+
+def test_live_config_carries_the_spec_2026_fields():
+    """The module-level config was built with the new fields populated."""
+    assert isinstance(config.spec_2026_enabled, bool)
+    assert isinstance(config.cache_ttl_ms, int)
+    assert config.cache_scope in ("public", "private")
+    assert isinstance(config.strict_headers, bool)
+
+
+def test_cache_ttl_ms_is_independent_of_the_metrics_cache_ttl():
+    """The advertised ttlMs must not be conflated with the in-process cache TTL."""
+    assert server._CACHE_TTL == 300
+    assert config.cache_ttl_ms == 300000
+
+
+# ---------------------------------------------------------------------------
+# Layer installation
+# ---------------------------------------------------------------------------
+
+def test_the_layer_is_installed_on_the_module_server():
+    """Import-time installation registered all three discovery paths."""
+    assert SPEC_2026_STATUS["negotiation"] is True
+    assert SPEC_2026_STATUS["envelope"] is True
+    assert SPEC_2026_STATUS["initialize_envelope"] is True
+    assert SPEC_2026_STATUS["discovery"] == {"jsonrpc": True, "http_route": True, "tool": True}
+
+
+def test_install_spec_2026_reports_every_layer():
+    """A clean install reports negotiation, discovery and both envelopes."""
+    fake_server = MagicMock()
+    with patch("prometheus_mcp_server.server.mcp", fake_server), \
+         patch("prometheus_mcp_server.server.install_negotiation", return_value=True) as negotiation, \
+         patch("prometheus_mcp_server.server.install_discovery", return_value={"jsonrpc": True}) as discovery, \
+         patch("prometheus_mcp_server.server.install_envelope", return_value=True) as envelope, \
+         patch("prometheus_mcp_server.server.install_initialize_envelope", return_value=True) as handshake:
+        status = install_spec_2026()
+
+    assert status == {
+        "negotiation": True,
+        "discovery": {"jsonrpc": True},
+        "envelope": True,
+        "initialize_envelope": True,
+    }
+    assert negotiation.call_count == 1
+    assert discovery.call_count == 1
+    assert envelope.call_count == 1
+    assert handshake.call_count == 1
+
+
+def test_install_spec_2026_reports_a_degraded_negotiation_layer():
+    """An unusable SDK shape degrades to discovery and envelope only."""
+    fake_server = MagicMock()
+    with patch("prometheus_mcp_server.server.mcp", fake_server), \
+         patch("prometheus_mcp_server.server.install_negotiation", return_value=False), \
+         patch("prometheus_mcp_server.server.install_discovery", return_value={"jsonrpc": True}), \
+         patch("prometheus_mcp_server.server.install_envelope", return_value=True), \
+         patch("prometheus_mcp_server.server.install_initialize_envelope", return_value=True):
+        status = install_spec_2026()
+
+    assert status["negotiation"] is False
+    assert status["envelope"] is True
+
+
+def test_install_spec_2026_never_raises():
+    """A failing sub-install is logged and the server keeps running."""
+    fake_server = MagicMock()
+    with patch("prometheus_mcp_server.server.mcp", fake_server), \
+         patch("prometheus_mcp_server.server.install_discovery", side_effect=RuntimeError("boom")):
+        status = install_spec_2026()
+
+    assert status == {
+        "negotiation": False,
+        "discovery": {},
+        "envelope": False,
+        "initialize_envelope": False,
+    }
+
+
+def test_install_spec_2026_is_idempotent():
+    """Regression: every call used to append another middleware instance.
+
+    The layer is installed at import time and re-installed by several test
+    modules against the same FastMCP singleton, so a non-idempotent installer
+    multiplies the per-request work (and the log noise) without bound.
+    """
+    import mcp.types as mcp_types
+
+    def wrapper_depth():
+        """Count the spec2026 wrappers stacked on one request handler."""
+        handler = mcp._mcp_server.request_handlers[mcp_types.ListToolsRequest]
+        depth = 0
+        while True:
+            inner = getattr(handler, "_spec2026_envelope_inner", None) or getattr(
+                handler, "_spec2026_negotiation_inner", None
+            )
+            if inner is None:
+                return depth
+            handler = inner
+            depth += 1
+
+    middleware_before = len(mcp.middleware)
+    baseline = wrapper_depth()
+
+    install_spec_2026()
+    install_spec_2026()
+
+    assert len(mcp.middleware) == middleware_before
+    assert wrapper_depth() == baseline
+
+
+# ---------------------------------------------------------------------------
+# F7 - trace context on the outbound Prometheus request
+# ---------------------------------------------------------------------------
+
+@patch("prometheus_mcp_server.server.requests.get")
+def test_trace_headers_are_forwarded_to_prometheus(mock_get, mock_response, restore_config):
+    """Validated trace context from _meta rides along on the outbound request."""
+    mock_get.return_value = mock_response
+    restore_config.url = "http://test:9090"
+    restore_config.custom_headers = None
+
+    token = set_trace_headers({"traceparent": VALID_TRACEPARENT, "baggage": "tenant=acme"})
+    try:
+        make_prometheus_request("query", params={"query": "up"})
+    finally:
+        server.reset_trace_headers(token)
+
+    headers = mock_get.call_args[1]["headers"]
+    assert headers["traceparent"] == VALID_TRACEPARENT
+    assert headers["baggage"] == "tenant=acme"
+
+
+@patch("prometheus_mcp_server.server.requests.get")
+def test_custom_headers_win_over_per_request_trace_headers(mock_get, mock_response, restore_config):
+    """Operator configuration must never be silently overwritten by a request."""
+    mock_get.return_value = mock_response
+    restore_config.url = "http://test:9090"
+    restore_config.custom_headers = {"traceparent": "operator-value"}
+
+    token = set_trace_headers({"traceparent": VALID_TRACEPARENT})
+    try:
+        make_prometheus_request("query", params={"query": "up"})
+    finally:
+        server.reset_trace_headers(token)
+
+    assert mock_get.call_args[1]["headers"]["traceparent"] == "operator-value"
+
+
+@patch("prometheus_mcp_server.server.requests.get")
+def test_no_trace_headers_without_request_context(mock_get, mock_response, restore_config):
+    """A 2025-11-25 client that sends no trace context sees no extra headers."""
+    mock_get.return_value = mock_response
+    restore_config.url = "http://test:9090"
+    restore_config.custom_headers = None
+
+    make_prometheus_request("query", params={"query": "up"})
+
+    headers = mock_get.call_args[1]["headers"]
+    assert "traceparent" not in headers
+    assert "baggage" not in headers
+
+
+# ---------------------------------------------------------------------------
+# F6 - the x-mcp-header annotated org_id parameter
+# ---------------------------------------------------------------------------
+
+def test_org_id_json_schema_collapses_the_optional_union():
+    """The annotation needs a primitive type, so the anyOf union is flattened.
+
+    The null default goes with it: `default: null` does not validate against
+    the `type: "string"` the annotation forces onto the property.
+    """
+    schema = {"anyOf": [{"type": "string"}, {"type": "null"}], "default": None}
+
+    _org_id_json_schema(schema)
+
+    assert schema == {"type": "string", "x-mcp-header": "Org-Id"}
+
+
+@pytest.mark.asyncio
+async def test_execute_query_declares_a_valid_header_annotation():
+    """The published inputSchema passes the specification's annotation rules."""
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+
+    tool = next(tool for tool in tools if tool.name == "execute_query")
+    org_id = tool.inputSchema["properties"]["org_id"]
+
+    assert org_id["x-mcp-header"] == "Org-Id"
+    assert org_id["type"] == "string"
+    assert validate_header_annotations(tool.inputSchema) == []
+
+
+@pytest.mark.asyncio
+async def test_the_published_input_schema_validates_its_own_default():
+    """Regression: the advertised schema contradicted itself.
+
+    ``default: null`` on a ``type: "string"`` property means a client that
+    validates its arguments against the published inputSchema -- or that
+    materialises declared defaults into the argument object, which several
+    tool-calling backends do -- rejects a call the server would have accepted.
+    """
+    jsonschema = pytest.importorskip("jsonschema")
+
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+
+    schema = next(tool for tool in tools if tool.name == "execute_query").inputSchema
+    org_id = schema["properties"]["org_id"]
+
+    validator = jsonschema.Draft202012Validator(schema)
+    assert list(validator.iter_errors({"query": "up"})) == []
+    assert list(validator.iter_errors({"query": "up", "org_id": "tenant-9"})) == []
+    # Echoing the advertised default back must validate against the schema.
+    assert list(validator.iter_errors({"query": "up", "org_id": org_id["default"]})) == []
+    jsonschema.Draft202012Validator.check_schema(schema)
+
+
+@pytest.mark.asyncio
+@patch("prometheus_mcp_server.server.make_prometheus_request")
+async def test_execute_query_forwards_the_org_id_argument(mock_make_request):
+    """A supplied org_id is threaded through to the Prometheus request."""
+    mock_make_request.return_value = {"resultType": "vector", "result": []}
+
+    await execute_query(query="up", org_id="tenant-9")
+
+    mock_make_request.assert_called_once_with("query", params={"query": "up"}, org_id="tenant-9")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("org_id", ["", None])
+@patch("prometheus_mcp_server.server.make_prometheus_request")
+async def test_execute_query_without_org_id_keeps_the_legacy_call(mock_make_request, org_id):
+    """Omitting the argument leaves the single-tenant call exactly as it was."""
+    mock_make_request.return_value = {"resultType": "vector", "result": []}
+
+    await execute_query(query="up", org_id=org_id)
+
+    mock_make_request.assert_called_once_with("query", params={"query": "up"})
+
+
+@patch("prometheus_mcp_server.server.requests.get")
+def test_a_configured_org_id_always_beats_the_client_supplied_one(mock_get, mock_response, restore_config):
+    """Regression: any caller could read another tenant's metrics.
+
+    X-Scope-OrgID is the only tenancy boundary in Mimir/Cortex/Thanos, and the
+    caller is typically an LLM acting on untrusted content, so an operator who
+    pinned ORG_ID must not have it displaced by a tool argument.
+    """
+    mock_get.return_value = mock_response
+    restore_config.url = "http://test:9090"
+    restore_config.org_id = "tenant-a"
+    restore_config.custom_headers = None
+    restore_config.allow_org_id_override = False
+
+    make_prometheus_request("query", params={"query": "up"}, org_id="tenant-b")
+
+    assert mock_get.call_args[1]["headers"]["X-Scope-OrgID"] == "tenant-a"
+
+
+@patch("prometheus_mcp_server.server.requests.get")
+def test_the_override_is_honoured_when_the_operator_opts_in(mock_get, mock_response, restore_config):
+    """Multi-tenant deployments can still opt into per-call tenants."""
+    mock_get.return_value = mock_response
+    restore_config.url = "http://test:9090"
+    restore_config.org_id = "tenant-a"
+    restore_config.custom_headers = None
+    restore_config.allow_org_id_override = True
+
+    make_prometheus_request("query", params={"query": "up"}, org_id="tenant-b")
+
+    assert mock_get.call_args[1]["headers"]["X-Scope-OrgID"] == "tenant-b"
+
+
+@patch("prometheus_mcp_server.server.requests.get")
+def test_a_per_call_tenant_applies_when_none_is_configured(mock_get, mock_response, restore_config):
+    """With no ORG_ID pinned there is no boundary to cross."""
+    mock_get.return_value = mock_response
+    restore_config.url = "http://test:9090"
+    restore_config.org_id = ""
+    restore_config.custom_headers = None
+    restore_config.allow_org_id_override = False
+
+    make_prometheus_request("query", params={"query": "up"}, org_id="tenant-b")
+
+    assert mock_get.call_args[1]["headers"]["X-Scope-OrgID"] == "tenant-b"
+
+
+@pytest.mark.parametrize("hostile", [
+    "acme\r\nX-Injected: yes",
+    "acme\nX-Injected: yes",
+    "acme\x00",
+    " acme",
+    "acme ",
+    "ünicode",
+    42,
+])
+@patch("prometheus_mcp_server.server.requests.get")
+def test_an_unsafe_org_id_never_reaches_an_outbound_header(mock_get, mock_response, restore_config, hostile):
+    """Regression: raw client input was written into X-Scope-OrgID unchecked.
+
+    requests' own header validation happens to block the CRLF case today, but
+    that turns a hostile argument into a RequestException instead of a clean
+    refusal, and any move off requests would make it a real injection.
+    """
+    mock_get.return_value = mock_response
+    restore_config.url = "http://test:9090"
+    restore_config.org_id = ""
+    restore_config.custom_headers = None
+    restore_config.allow_org_id_override = True
+
+    make_prometheus_request("query", params={"query": "up"}, org_id=hostile)
+
+    assert "X-Scope-OrgID" not in mock_get.call_args[1]["headers"]
+
+
+def test_resolve_org_id_falls_back_to_the_configured_tenant(restore_config):
+    """An unsafe per-call value must not disable the configured tenant either."""
+    restore_config.org_id = "tenant-a"
+    restore_config.allow_org_id_override = True
+
+    assert resolve_org_id("acme\r\nX-Injected: yes") == "tenant-a"
+    assert resolve_org_id("tenant-b") == "tenant-b"
+    assert resolve_org_id(None) == "tenant-a"
+
+
+# ---------------------------------------------------------------------------
+# Request-context helpers
+# ---------------------------------------------------------------------------
+
+def test_current_request_meta_is_none_outside_a_request():
+    """No request in scope must not raise; there is simply nothing to read."""
+    assert _current_request_meta() is None
+
+
+def test_current_request_meta_reads_the_sdk_context():
+    """The authoritative _meta comes from the SDK's own request context."""
+    request_context = MagicMock()
+    request_context.meta = {"io.modelcontextprotocol/protocolVersion": "2026-07-28"}
+
+    token = server._sdk_request_ctx.set(request_context)
+    try:
+        assert _current_request_meta() == request_context.meta
+    finally:
+        server._sdk_request_ctx.reset(token)
+
+
+def test_current_request_meta_degrades_when_the_context_misbehaves():
+    """An unexpected SDK failure is logged, not propagated."""
+    broken = MagicMock()
+    broken.get.side_effect = RuntimeError("boom")
+
+    with patch("prometheus_mcp_server.server._sdk_request_ctx", broken):
+        assert _current_request_meta() is None
+
+
+def test_current_request_meta_is_none_without_the_sdk_context():
+    """An incompatible SDK leaves the negotiation layer inert, not broken."""
+    with patch("prometheus_mcp_server.server._sdk_request_ctx", None):
+        assert _current_request_meta() is None
+
+
+@pytest.mark.asyncio
+async def test_tool_header_annotations_reads_the_registered_tool():
+    """execute_query's Org-Id annotation is discoverable from the registry."""
+    annotations = await tool_header_annotations("execute_query")
+
+    assert [annotation.header_name for annotation in annotations] == ["Mcp-Param-Org-Id"]
+    assert annotations[0].path == ("org_id",)
+
+
+@pytest.mark.asyncio
+async def test_tool_header_annotations_handles_a_missing_tool():
+    """An unresolvable tool yields no annotations instead of raising."""
+    assert await tool_header_annotations("no-such-tool") == []
+
+
+@pytest.mark.asyncio
+async def test_tool_header_annotations_survives_a_registry_failure():
+    """A registry that raises degrades to "no annotations", never to a 500."""
+    async def explode(_name):
+        raise RuntimeError("registry down")
+
+    with patch.object(mcp, "get_tool", explode):
+        assert await tool_header_annotations("execute_query") == []
+
+
+@pytest.mark.asyncio
+async def test_tool_header_annotations_ignores_a_non_string_name():
+    """A malformed tool name is rejected before the registry is touched."""
+    assert await tool_header_annotations(None) == []
+
+
+# ---------------------------------------------------------------------------
+# F6 - strict header validation is wired in at the ASGI layer
+# ---------------------------------------------------------------------------
+
+def test_strict_header_middleware_is_absent_unless_enabled(restore_config):
+    """The switch is opt-in, so nothing is added by default."""
+    restore_config.strict_headers = False
+    assert strict_header_asgi_middleware() is None
+
+
+def test_strict_header_middleware_is_built_when_enabled(restore_config):
+    """Turning the switch on yields a Starlette middleware entry."""
+    restore_config.strict_headers = True
+    entry = strict_header_asgi_middleware()
+
+    assert entry is not None
+    assert entry.cls is StrictHeaderMiddleware
+
+
+def test_strict_header_middleware_degrades_instead_of_raising(restore_config):
+    """An unavailable Starlette must not stop the server from starting."""
+    restore_config.strict_headers = True
+    with patch("prometheus_mcp_server.server.strict_header_middleware", side_effect=RuntimeError("boom")):
+        assert strict_header_asgi_middleware() is None
+
+
+def test_run_server_passes_the_middleware_to_the_http_transport(restore_config):
+    """main.py must actually hand the middleware to FastMCP, not just build it."""
+    import prometheus_mcp_server.main as main_module
+
+    restore_config.strict_headers = True
+    sentinel = object()
+
+    with patch.object(main_module, "setup_environment", return_value=True), \
+         patch.object(main_module.config, "mcp_server_config",
+                      server.MCPServerConfig(mcp_server_transport="http", mcp_bind_host="h", mcp_bind_port=1)), \
+         patch.object(main_module, "strict_header_asgi_middleware", return_value=sentinel), \
+         patch.object(main_module.mcp, "run") as run:
+        main_module.run_server()
+
+    assert run.call_args[1]["middleware"] == [sentinel]
+
+
+def test_run_server_adds_no_middleware_when_strict_headers_are_off():
+    """The default HTTP run path stays byte-for-byte what it was."""
+    import prometheus_mcp_server.main as main_module
+
+    with patch.object(main_module, "setup_environment", return_value=True), \
+         patch.object(main_module.config, "mcp_server_config",
+                      server.MCPServerConfig(mcp_server_transport="http", mcp_bind_host="h", mcp_bind_port=1)), \
+         patch.object(main_module, "strict_header_asgi_middleware", return_value=None), \
+         patch.object(main_module.mcp, "run") as run:
+        main_module.run_server()
+
+    assert "middleware" not in run.call_args[1]
+
+
+# ---------------------------------------------------------------------------
+# F5 - the negotiation wrapper
+#
+# Negotiation lives below FastMCP, on the low-level request handlers, because
+# FastMCP renders an exception raised during tools/call as a successful result
+# with isError=true -- which strips the -32022 code and the data.supported list
+# a client needs in order to renegotiate.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_negotiation_publishes_and_resets_the_request_state():
+    """Negotiation and trace state live only for the duration of the request."""
+    observed = {}
+
+    async def handler(_req):
+        observed["negotiation"] = get_current_negotiation()
+        observed["trace"] = get_trace_headers()
+        return "done"
+
+    meta = {
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientInfo": {"name": "probe"},
+        "traceparent": VALID_TRACEPARENT,
+    }
+
+    with patch("prometheus_mcp_server.server._current_request_meta", return_value=meta):
+        result = await _wrap_negotiation(handler)(None)
+
+    assert result == "done"
+    assert observed["negotiation"].protocol_version == "2026-07-28"
+    assert observed["negotiation"].client_info == {"name": "probe"}
+    assert observed["trace"] == {"traceparent": VALID_TRACEPARENT}
+    # Nothing survives into the next request.
+    assert get_current_negotiation() is None
+    assert get_trace_headers() == {}
+
+
+@pytest.mark.asyncio
+async def test_negotiation_resets_state_even_when_the_handler_raises():
+    """The reset lives in a finally block, so a failure cannot leak state."""
+
+    async def handler(_req):
+        raise ValueError("handler exploded")
+
+    meta = {"io.modelcontextprotocol/protocolVersion": "2026-07-28", "traceparent": VALID_TRACEPARENT}
+
+    with patch("prometheus_mcp_server.server._current_request_meta", return_value=meta):
+        with pytest.raises(ValueError):
+            await _wrap_negotiation(handler)(None)
+
+    assert get_current_negotiation() is None
+    assert get_trace_headers() == {}
+
+
+@pytest.mark.asyncio
+async def test_negotiation_accepts_a_legacy_request_without_a_protocol_version():
+    """A 2025-11-25 client that declares nothing is served normally."""
+    observed = {}
+
+    async def handler(_req):
+        observed["negotiation"] = get_current_negotiation()
+        return "done"
+
+    with patch("prometheus_mcp_server.server._current_request_meta", return_value=None):
+        assert await _wrap_negotiation(handler)(None) == "done"
+
+    assert observed["negotiation"].is_legacy is True
+    assert observed["negotiation"].may_log is False
+
+
+@pytest.mark.asyncio
+async def test_negotiation_rejects_an_unsupported_protocol_version():
+    """An unrecognised version fails with JSON-RPC code -32022."""
+
+    async def handler(_req):  # pragma: no cover - must never be reached
+        raise AssertionError("handler must not run")
+
+    meta = {"io.modelcontextprotocol/protocolVersion": "1999-01-01"}
+
+    with patch("prometheus_mcp_server.server._current_request_meta", return_value=meta):
+        with pytest.raises(McpError) as excinfo:
+            await _wrap_negotiation(handler)(None)
+
+    assert excinfo.value.error.code == -32022
+    assert excinfo.value.error.data["requested"] == "1999-01-01"
+    assert "2026-07-28" in excinfo.value.error.data["supported"]
+
+
+@pytest.mark.asyncio
+async def test_negotiation_supports_a_synchronous_handler():
+    """The SDK's handlers are async, but the wrapper must not assume it."""
+    def handler(_req):
+        return "sync"
+
+    with patch("prometheus_mcp_server.server._current_request_meta", return_value=None):
+        assert await _wrap_negotiation(handler)(None) == "sync"
+
+
+def test_install_negotiation_degrades_without_request_handlers():
+    """An incompatible SDK leaves the layer off rather than crashing."""
+    assert install_negotiation(MagicMock(_mcp_server=MagicMock(request_handlers=None))) is False
+
+
+def test_install_negotiation_reports_an_empty_handler_table():
+    """Nothing to wrap means the layer is inactive, not installed."""
+    assert install_negotiation(MagicMock(_mcp_server=MagicMock(request_handlers={}))) is False
+
+
+def test_install_negotiation_skips_a_non_callable_handler():
+    """A handler table holding junk is logged, not dereferenced."""
+    handlers = {object(): "not callable"}
+    assert install_negotiation(MagicMock(_mcp_server=MagicMock(request_handlers=handlers))) is False
+
+
+def test_install_negotiation_never_raises():
+    """Any unexpected failure degrades to False."""
+    broken = MagicMock()
+    type(broken)._mcp_server = property(lambda self: (_ for _ in ()).throw(RuntimeError("boom")))
+    assert install_negotiation(broken) is False
+
+
+# ---------------------------------------------------------------------------
+# End-to-end behaviour through the in-memory client
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_tools_list_is_sorted_and_enveloped():
+    """F2/F3: results carry the envelope and tools come back in name order."""
+    import mcp.types as mcp_types
+
+    async with Client(mcp) as client:
+        result = await client.session.send_request(
+            mcp_types.ClientRequest(mcp_types.ListToolsRequest()),
+            mcp_types.ListToolsResult,
+        )
+
+    payload = result.model_dump(by_alias=True, exclude_none=True)
+    names = [tool["name"] for tool in payload["tools"]]
+
+    assert names == sorted(names)
+    assert payload["resultType"] == "complete"
+    assert payload["ttlMs"] == config.cache_ttl_ms
+    assert payload["cacheScope"] == config.cache_scope
+    assert payload["_meta"]["io.modelcontextprotocol/serverInfo"] == {
+        "name": server.mcp_name,
+        "version": server.SERVER_VERSION,
+    }
+
+
+@pytest.mark.asyncio
+async def test_server_discover_is_dispatched_as_a_json_rpc_method():
+    """F4: server/discover answers over the real JSON-RPC path."""
+    import mcp.types as mcp_types
+    from prometheus_mcp_server.spec2026.discovery import DiscoverRequest, DiscoverResult
+
+    async with Client(mcp) as client:
+        result = await client.session.send_request(
+            mcp_types.ClientRequest(DiscoverRequest()),
+            DiscoverResult,
+        )
+
+    payload = result.model_dump(by_alias=True, exclude_none=True)
+
+    assert payload["resultType"] == "complete"
+    assert payload["supportedVersions"][0] == "2026-07-28"
+    assert payload["capabilities"]["extensions"] == {}
+    assert payload["cacheScope"] == "public"
+    assert payload["_meta"]["io.modelcontextprotocol/serverInfo"]["version"] == server.SERVER_VERSION
+
+
+@pytest.mark.asyncio
+async def test_server_discover_is_also_an_mcp_tool():
+    """F4: the payload stays reachable as a tool on every transport."""
+    async with Client(mcp) as client:
+        result = await client.call_tool("server_discover", {})
+
+    assert result.data["supportedVersions"][0] == "2026-07-28"
+
+
+def test_server_discover_http_route_serves_the_payload():
+    """F4: GET /server/discover is the pre-handshake answer for HTTP clients."""
+    routes = {
+        route.path: route
+        for route in mcp.http_app().routes
+        if hasattr(route, "path")
+    }
+    assert "/server/discover" in routes
+
+    response = asyncio.run(routes["/server/discover"].endpoint(MagicMock()))
+    payload = json.loads(response.body)
+
+    assert response.status_code == 200
+    assert payload["supportedVersions"] == ["2026-07-28", "2025-11-25", "2025-06-18"]
+    assert payload["ttlMs"] == 3600000
+
+
+@pytest.mark.asyncio
+async def test_tools_list_envelope_fields_satisfy_the_specification():
+    """F2: the envelope fields are spec-valid in their own right, not just equal
+    to config -- ttlMs is a non-negative integer and cacheScope is an enum member.
+    """
+    import mcp.types as mcp_types
+
+    async with Client(mcp) as client:
+        result = await client.session.send_request(
+            mcp_types.ClientRequest(mcp_types.ListToolsRequest()),
+            mcp_types.ListToolsResult,
+        )
+
+    payload = result.model_dump(by_alias=True, exclude_none=True)
+
+    assert payload["resultType"] == "complete"
+    # bool is a subclass of int, so an accidental True would satisfy a bare
+    # isinstance check while serializing as `true` on the wire.
+    assert isinstance(payload["ttlMs"], int) and not isinstance(payload["ttlMs"], bool)
+    assert payload["ttlMs"] >= 0
+    assert payload["cacheScope"] in ("public", "private")
+
+    server_info = payload["_meta"]["io.modelcontextprotocol/serverInfo"]
+    assert server_info["name"] and isinstance(server_info["name"], str)
+    assert server_info["version"] and isinstance(server_info["version"], str)
+
+
+@pytest.mark.asyncio
+async def test_tools_list_order_is_the_sorted_registry():
+    """F3: the published order is the registry sorted by name, deterministically."""
+    async with Client(mcp) as client:
+        first = await client.list_tools()
+        second = await client.list_tools()
+
+    # run_middleware=False reads the registry directly, so this is the raw
+    # registration order the envelope is expected to sort.
+    registered = sorted(tool.name for tool in await mcp.list_tools(run_middleware=False))
+    names = [tool.name for tool in first]
+
+    assert len(names) > 1, "need several tools for the ordering assertion to mean anything"
+    assert names == registered
+    assert names == [tool.name for tool in second], "ordering must be stable across calls"
+
+
+@pytest.mark.asyncio
+@patch("prometheus_mcp_server.server.requests.get")
+async def test_tools_call_carries_result_type_but_no_cache_fields(mock_get, mock_response, restore_config):
+    """F2: tools/call is not in the cacheable set, so it gets no ttlMs/cacheScope."""
+    mock_get.return_value = mock_response
+    restore_config.url = "http://test:9090"
+
+    async with Client(mcp) as client:
+        result = await client.session.call_tool("execute_query", {"query": "up"})
+
+    payload = result.model_dump(by_alias=True, mode="json", exclude_none=True)
+
+    assert result.isError is False
+    assert payload["resultType"] == "complete"
+    assert payload["_meta"]["io.modelcontextprotocol/serverInfo"] == {
+        "name": server.mcp_name,
+        "version": server.SERVER_VERSION,
+    }
+    assert "ttlMs" not in payload
+    assert "cacheScope" not in payload
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility: PROMETHEUS_MCP_SPEC_2026=false
+#
+# The switch is read at import time, so the guarantee can only be tested by
+# loading a second, independent copy of server.py with the variable unset. The
+# copy is deliberately not registered in sys.modules: it must not shadow the
+# real module for any other test.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def legacy_server():
+    """Load a fresh copy of server.py with the 2026 layer switched off."""
+    with patch.dict(os.environ, {"PROMETHEUS_MCP_SPEC_2026": "false"}):
+        spec = importlib.util.spec_from_file_location(
+            "prometheus_mcp_server._server_spec2026_disabled", server.__file__
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    return module
+
+
+def test_disabled_layer_is_not_installed(legacy_server):
+    """The master switch turns the whole layer off, not just parts of it."""
+    assert legacy_server.config.spec_2026_enabled is False
+    assert legacy_server.SPEC_2026_STATUS == {}
+
+
+@pytest.mark.asyncio
+async def test_disabled_layer_serves_plain_2025_results(legacy_server):
+    """A 2025-11-25 client sees byte-for-byte the results it always saw."""
+    import mcp.types as mcp_types
+
+    async with Client(legacy_server.mcp) as client:
+        result = await client.session.send_request(
+            mcp_types.ClientRequest(mcp_types.ListToolsRequest()),
+            mcp_types.ListToolsResult,
+        )
+
+    payload = result.model_dump(by_alias=True, exclude_none=True)
+
+    assert list(payload.keys()) == ["tools"]
+    assert "resultType" not in payload
+    assert "ttlMs" not in payload
+    assert "cacheScope" not in payload
+    assert "_meta" not in payload
+    # Untouched means unsorted: the order is the registration order FastMCP
+    # itself reports, which is exactly what a 2025-11-25 client used to get.
+    registration_order = [
+        tool.name for tool in await legacy_server.mcp.list_tools(run_middleware=False)
+    ]
+    assert [tool.name for tool in result.tools] == registration_order
+    assert registration_order != sorted(registration_order), (
+        "the fixture is only meaningful while registration order differs from sorted order"
+    )
+
+
+@pytest.mark.asyncio
+async def test_disabled_layer_registers_no_discovery_surfaces(legacy_server):
+    """server/discover is part of the layer and must vanish with it."""
+    async with Client(legacy_server.mcp) as client:
+        tools = {tool.name for tool in await client.list_tools()}
+
+    assert "server_discover" not in tools
+
+    paths = {route.path for route in legacy_server.mcp.http_app().routes if hasattr(route, "path")}
+    assert "/server/discover" not in paths
+    assert "/health" in paths, "the pre-existing health route must survive"
+
+
+@pytest.mark.asyncio
+async def test_disabled_layer_still_queries_prometheus_end_to_end(legacy_server, mock_response):
+    """The actual job of the server keeps working with the layer switched off."""
+    legacy_server.config.url = "http://test:9090"
+    mock_response.json.return_value = {
+        "status": "success",
+        "data": {"resultType": "vector", "result": [{"metric": {"job": "api"}, "value": [1, "1"]}]},
+    }
+
+    with patch.object(legacy_server.requests, "get", return_value=mock_response) as mock_get:
+        async with Client(legacy_server.mcp) as client:
+            # session.call_tool returns the raw protocol CallToolResult, which is
+            # what the envelope would have decorated; the fastmcp-level wrapper
+            # returned by client.call_tool drops any unknown top-level fields.
+            result = await client.session.call_tool("execute_query", {"query": "up"})
+
+    assert result.isError is False
+    assert result.structuredContent["resultType"] == "vector"
+    assert result.structuredContent["result"][0]["metric"] == {"job": "api"}
+    assert mock_get.call_args[0][0] == "http://test:9090/api/v1/query"
+    # No trace-context plumbing runs, so the outbound headers stay empty.
+    assert mock_get.call_args[1]["headers"] == {}
+
+    payload = result.model_dump(by_alias=True, mode="json", exclude_none=True)
+    assert "resultType" not in payload, "the CallToolResult envelope must stay off"
+    assert "_meta" not in payload
+
+
+@pytest.mark.asyncio
+async def test_disabled_layer_ignores_a_2026_protocol_version(legacy_server):
+    """Without the negotiation middleware an unknown version is not rejected.
+
+    The layer is off, so the server behaves exactly as 2025-11-25 does: _meta is
+    passed through untouched and no -32022 is raised.
+    """
+    import mcp.types as mcp_types
+
+    request = mcp_types.ListToolsRequest(
+        params=mcp_types.PaginatedRequestParams(
+            _meta=mcp_types.RequestParams.Meta.model_validate(
+                {"io.modelcontextprotocol/protocolVersion": "1999-01-01"}
+            )
+        )
+    )
+
+    async with Client(legacy_server.mcp) as client:
+        result = await client.session.send_request(
+            mcp_types.ClientRequest(request), mcp_types.ListToolsResult
+        )
+
+    assert len(result.tools) > 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.filterwarnings("ignore::UserWarning")
+async def test_an_unknown_method_is_still_rejected():
+    """Extending the request union must not make the server accept anything."""
+    import mcp.types as mcp_types
+    from pydantic import ConfigDict
+
+    class BogusRequest(mcp_types.Request):
+        model_config = ConfigDict(extra="allow")
+        method: str = "bogus/method"
+        params: None = None
+
+    async with Client(mcp) as client:
+        with pytest.raises(McpError) as excinfo:
+            await client.session.send_request(
+                mcp_types.ClientRequest.model_construct(root=BogusRequest()),
+                mcp_types.EmptyResult,
+            )
+
+    assert excinfo.value.error.code == -32602
+
+
+# ---------------------------------------------------------------------------
+# F5 end to end: the JSON-RPC error code must survive tools/call
+# ---------------------------------------------------------------------------
+
+def _call_tool_request(name, arguments, protocol_version=None):
+    """Build a CallToolRequest optionally declaring a protocol version."""
+    import mcp.types as mcp_types
+
+    meta = None
+    if protocol_version is not None:
+        meta = mcp_types.RequestParams.Meta.model_validate(
+            {"io.modelcontextprotocol/protocolVersion": protocol_version}
+        )
+    return mcp_types.CallToolRequest(
+        params=mcp_types.CallToolRequestParams(name=name, arguments=arguments, _meta=meta)
+    )
+
+
+@pytest.mark.asyncio
+async def test_tools_call_reports_an_unsupported_version_as_a_json_rpc_error():
+    """Regression: -32022 was downgraded to a resultType "complete" tool result.
+
+    FastMCP renders an exception raised inside its middleware chain during
+    tools/call as a successful CallToolResult with isError=true, so the client
+    saw a well-formed *complete* result, could not read the code, and never
+    received the data.supported list it needs in order to renegotiate.
+    """
+    import mcp.types as mcp_types
+
+    async with Client(mcp) as client:
+        with pytest.raises(McpError) as excinfo:
+            await client.session.send_request(
+                mcp_types.ClientRequest(
+                    _call_tool_request("health_check", {}, protocol_version="1999-01-01")
+                ),
+                mcp_types.CallToolResult,
+            )
+
+    assert excinfo.value.error.code == -32022
+    assert excinfo.value.error.data["requested"] == "1999-01-01"
+    assert "2026-07-28" in excinfo.value.error.data["supported"]
+
+
+@pytest.mark.asyncio
+async def test_tools_list_reports_the_same_code_as_tools_call():
+    """The two paths must not disagree about a protocol-level rejection."""
+    import mcp.types as mcp_types
+
+    request = mcp_types.ListToolsRequest(
+        params=mcp_types.PaginatedRequestParams(
+            _meta=mcp_types.RequestParams.Meta.model_validate(
+                {"io.modelcontextprotocol/protocolVersion": "1999-01-01"}
+            )
+        )
+    )
+
+    async with Client(mcp) as client:
+        with pytest.raises(McpError) as excinfo:
+            await client.session.send_request(
+                mcp_types.ClientRequest(request), mcp_types.ListToolsResult
+            )
+
+    assert excinfo.value.error.code == -32022
+
+
+@pytest.mark.asyncio
+@patch("prometheus_mcp_server.server.requests.get")
+async def test_trace_context_still_reaches_prometheus_through_the_wrapper(
+    mock_get, mock_response, restore_config
+):
+    """Negotiation moved below FastMCP; the contextvars must still be published."""
+    import mcp.types as mcp_types
+
+    mock_get.return_value = mock_response
+    restore_config.url = "http://test:9090"
+    restore_config.custom_headers = None
+
+    request = mcp_types.CallToolRequest(
+        params=mcp_types.CallToolRequestParams(
+            name="execute_query",
+            arguments={"query": "up"},
+            _meta=mcp_types.RequestParams.Meta.model_validate(
+                {
+                    "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                    "traceparent": VALID_TRACEPARENT,
+                }
+            ),
+        )
+    )
+
+    async with Client(mcp) as client:
+        result = await client.session.send_request(
+            mcp_types.ClientRequest(request), mcp_types.CallToolResult
+        )
+
+    assert result.isError is False
+    assert mock_get.call_args[1]["headers"]["traceparent"] == VALID_TRACEPARENT
+    # And it does not leak past the request.
+    assert get_trace_headers() == {}

--- a/tests/test_spec2026_negotiation.py
+++ b/tests/test_spec2026_negotiation.py
@@ -1,0 +1,504 @@
+"""Tests for MCP 2026-07-28 per-request negotiation (F5)."""
+
+import pytest
+
+from prometheus_mcp_server.spec2026.constants import (
+    META_CLIENT_CAPABILITIES,
+    META_CLIENT_INFO,
+    META_LOG_LEVEL,
+    META_PROTOCOL_VERSION,
+    PROTOCOL_VERSION_2025_06,
+    PROTOCOL_VERSION_2025_11,
+    PROTOCOL_VERSION_2026,
+    SUPPORTED_PROTOCOL_VERSIONS,
+    UNSUPPORTED_PROTOCOL_VERSION,
+)
+from prometheus_mcp_server.spec2026.negotiation import (
+    NegotiationError,
+    _coerce_mapping,
+    RequestNegotiation,
+    UnsupportedProtocolVersionError,
+    clear_current_negotiation,
+    current_log_level,
+    extract_request_meta,
+    get_current_negotiation,
+    may_emit_log_notifications,
+    negotiate_request,
+    negotiation_from_meta,
+    negotiation_scope,
+    reset_current_negotiation,
+    set_current_negotiation,
+    validate_protocol_version,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_negotiation_context():
+    """Guarantee a clean context var before and after every test."""
+    clear_current_negotiation()
+    yield
+    clear_current_negotiation()
+
+
+def make_request(meta):
+    """Build a raw JSON-RPC style request dict carrying the given _meta."""
+    return {"method": "tools/list", "params": {"_meta": meta}}
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+def test_error_code_and_supported_versions_are_as_specified():
+    """The 2026-07-28 error code and version list match the specification."""
+    assert UNSUPPORTED_PROTOCOL_VERSION == -32022
+    assert SUPPORTED_PROTOCOL_VERSIONS == (
+        "2026-07-28",
+        "2025-11-25",
+        "2025-06-18",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Absent _meta (legacy clients)
+# ---------------------------------------------------------------------------
+
+def test_extract_meta_from_request_without_params():
+    """A request with no params yields an empty _meta."""
+    assert extract_request_meta({"method": "tools/list"}) == {}
+
+
+def test_extract_meta_from_params_without_meta():
+    """Params without a _meta member yield an empty _meta."""
+    assert extract_request_meta({"method": "tools/list", "params": {"name": "x"}}) == {}
+
+
+def test_extract_meta_from_none_request():
+    """A None request yields an empty _meta rather than raising."""
+    assert extract_request_meta(None) == {}
+
+
+def test_extract_meta_when_meta_is_explicitly_none():
+    """An explicit _meta of None yields an empty _meta."""
+    assert extract_request_meta(make_request(None)) == {}
+
+
+def test_absent_meta_is_legacy_and_does_not_error():
+    """A legacy client that sends no _meta negotiates successfully."""
+    negotiation = negotiate_request({"method": "tools/list"})
+
+    assert negotiation.protocol_version is None
+    assert negotiation.is_legacy is True
+    assert negotiation.client_capabilities == {}
+    assert negotiation.client_info == {}
+    assert negotiation.log_level is None
+    assert negotiation.meta == {}
+
+
+def test_absent_protocol_version_with_other_meta_present():
+    """Other _meta keys are read even when no protocol version is declared."""
+    negotiation = negotiate_request(make_request({"traceparent": "abc"}))
+
+    assert negotiation.protocol_version is None
+    assert negotiation.meta == {"traceparent": "abc"}
+
+
+def test_validate_protocol_version_accepts_none():
+    """Validation of an absent version returns None instead of raising."""
+    assert validate_protocol_version(None) is None
+
+
+# ---------------------------------------------------------------------------
+# Malformed _meta
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("bad_meta", ["not-a-dict", ["a", "b"], 42, True])
+def test_extract_meta_ignores_non_mapping_meta(bad_meta):
+    """A _meta that is not an object degrades to an empty mapping."""
+    assert extract_request_meta(make_request(bad_meta)) == {}
+
+
+@pytest.mark.parametrize("bad_meta", ["not-a-dict", ["a", "b"], 42, None])
+def test_negotiation_from_malformed_meta_is_legacy(bad_meta):
+    """Malformed _meta negotiates as a legacy request rather than erroring."""
+    negotiation = negotiation_from_meta(bad_meta)
+
+    assert negotiation.protocol_version is None
+    assert negotiation.meta == {}
+
+
+def test_malformed_client_capabilities_are_dropped():
+    """A non-object clientCapabilities value degrades to an empty dict."""
+    negotiation = negotiate_request(
+        make_request(
+            {
+                META_PROTOCOL_VERSION: PROTOCOL_VERSION_2026,
+                META_CLIENT_CAPABILITIES: "tools",
+                META_CLIENT_INFO: ["nope"],
+            }
+        )
+    )
+
+    assert negotiation.client_capabilities == {}
+    assert negotiation.client_info == {}
+    assert negotiation.protocol_version == PROTOCOL_VERSION_2026
+
+
+def test_non_string_meta_keys_are_stringified():
+    """Non-string _meta keys do not break extraction."""
+    assert extract_request_meta(make_request({1: "one"})) == {"1": "one"}
+
+
+class _ExplodingModel:
+    """Stand-in for an SDK model whose model_dump raises."""
+
+    model_extra = {"io.modelcontextprotocol/protocolVersion": "2026-07-28"}
+
+    def model_dump(self, **kwargs):
+        raise TypeError("unexpected keyword argument")
+
+
+class _NonDictDumpModel:
+    """Stand-in for an SDK model whose model_dump stops returning a dict."""
+
+    model_extra = {"io.modelcontextprotocol/logLevel": "debug"}
+
+    def model_dump(self, **kwargs):
+        return ["not", "a", "dict"]
+
+
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        (_ExplodingModel(), {META_PROTOCOL_VERSION: PROTOCOL_VERSION_2026}),
+        (_NonDictDumpModel(), {META_LOG_LEVEL: "debug"}),
+    ],
+)
+def test_meta_model_falls_back_to_model_extra(model, expected):
+    """A model_dump that raises or misbehaves degrades to model_extra."""
+    assert extract_request_meta(make_request(model)) == expected
+
+
+def test_coerce_mapping_returns_none_for_none():
+    """The mapping coercion helper treats None as 'no mapping'."""
+    assert _coerce_mapping(None) is None
+
+
+def test_coerce_mapping_returns_none_for_opaque_object():
+    """An object with neither model_dump nor model_extra is not a mapping."""
+    assert _coerce_mapping(object()) is None
+
+
+# ---------------------------------------------------------------------------
+# Supported protocol versions
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "version",
+    [PROTOCOL_VERSION_2026, PROTOCOL_VERSION_2025_11, PROTOCOL_VERSION_2025_06],
+)
+def test_supported_protocol_versions_are_accepted(version):
+    """Every advertised version negotiates successfully."""
+    negotiation = negotiate_request(make_request({META_PROTOCOL_VERSION: version}))
+
+    assert negotiation.protocol_version == version
+    assert negotiation.is_legacy is False
+
+
+def test_supported_version_captures_capabilities_and_client_info():
+    """Client capabilities and info are captured verbatim for the request."""
+    negotiation = negotiate_request(
+        make_request(
+            {
+                META_PROTOCOL_VERSION: PROTOCOL_VERSION_2026,
+                META_CLIENT_CAPABILITIES: {"tools": {"listChanged": True}},
+                META_CLIENT_INFO: {"name": "probe", "version": "9.9.9"},
+            }
+        )
+    )
+
+    assert negotiation.client_capabilities == {"tools": {"listChanged": True}}
+    assert negotiation.client_info == {"name": "probe", "version": "9.9.9"}
+
+
+def test_capabilities_are_copied_not_aliased():
+    """Mutating the caller's dict cannot alter captured capabilities."""
+    capabilities = {"tools": {}}
+    negotiation = negotiation_from_meta(
+        {
+            META_PROTOCOL_VERSION: PROTOCOL_VERSION_2026,
+            META_CLIENT_CAPABILITIES: capabilities,
+        }
+    )
+
+    capabilities["sampling"] = {}
+
+    assert negotiation.client_capabilities == {"tools": {}}
+
+
+def test_meta_is_preserved_for_downstream_modules():
+    """Unmodelled _meta keys survive so trace context can be forwarded."""
+    negotiation = negotiate_request(
+        make_request(
+            {
+                META_PROTOCOL_VERSION: PROTOCOL_VERSION_2026,
+                "traceparent": "00-" + "a" * 32 + "-" + "b" * 16 + "-01",
+            }
+        )
+    )
+
+    assert negotiation.meta["traceparent"] == "00-" + "a" * 32 + "-" + "b" * 16 + "-01"
+
+
+def test_pydantic_meta_model_is_supported():
+    """A pydantic RequestParams.Meta (extra=allow) is read like a dict."""
+    types = pytest.importorskip("mcp.types")
+
+    params = types.RequestParams(
+        _meta=types.RequestParams.Meta.model_validate(
+            {META_PROTOCOL_VERSION: PROTOCOL_VERSION_2026, META_LOG_LEVEL: "debug"}
+        )
+    )
+    negotiation = negotiate_request(types.PingRequest(params=params))
+
+    assert negotiation.protocol_version == PROTOCOL_VERSION_2026
+    assert negotiation.log_level == "debug"
+
+
+# ---------------------------------------------------------------------------
+# Unsupported protocol version
+# ---------------------------------------------------------------------------
+
+def test_unsupported_protocol_version_raises_32022_with_data():
+    """An unrecognised version raises -32022 carrying supported/requested."""
+    with pytest.raises(UnsupportedProtocolVersionError) as excinfo:
+        negotiate_request(make_request({META_PROTOCOL_VERSION: "1999-01-01"}))
+
+    error = excinfo.value
+    assert error.code == -32022
+    assert error.code == UNSUPPORTED_PROTOCOL_VERSION
+    assert error.data == {
+        "supported": ["2026-07-28", "2025-11-25", "2025-06-18"],
+        "requested": "1999-01-01",
+    }
+    assert error.requested == "1999-01-01"
+    assert "1999-01-01" in error.message
+    assert isinstance(error, NegotiationError)
+
+
+def test_unsupported_protocol_version_error_data_round_trips():
+    """to_error_data renders the full JSON-RPC error object."""
+    with pytest.raises(UnsupportedProtocolVersionError) as excinfo:
+        validate_protocol_version("2024-01-01")
+
+    payload = excinfo.value.to_error_data()
+
+    assert payload["code"] == -32022
+    assert payload["data"]["requested"] == "2024-01-01"
+    assert payload["data"]["supported"] == list(SUPPORTED_PROTOCOL_VERSIONS)
+    assert isinstance(payload["message"], str)
+
+
+def test_unsupported_protocol_version_converts_to_mcp_error():
+    """The error converts to an SDK McpError carrying the same payload."""
+    mcp_exceptions = pytest.importorskip("mcp.shared.exceptions")
+
+    error = UnsupportedProtocolVersionError("1999-01-01").to_mcp_error()
+
+    assert isinstance(error, mcp_exceptions.McpError)
+    assert error.error.code == -32022
+    assert error.error.data["requested"] == "1999-01-01"
+
+
+@pytest.mark.parametrize("bad_version", [42, ["2026-07-28"], "", "   ", {"v": 1}])
+def test_non_string_protocol_versions_are_rejected(bad_version):
+    """A present-but-unusable version is rejected, never silently accepted."""
+    with pytest.raises(UnsupportedProtocolVersionError) as excinfo:
+        validate_protocol_version(bad_version)
+
+    assert excinfo.value.code == -32022
+    assert isinstance(excinfo.value.data["requested"], str)
+
+
+def test_negotiation_error_carries_arbitrary_code():
+    """The base error is reusable for the other 2026-07-28 codes."""
+    error = NegotiationError(-32020, "HeaderMismatch", {"header": "Mcp-Method"})
+
+    assert error.to_error_data() == {
+        "code": -32020,
+        "message": "HeaderMismatch",
+        "data": {"header": "Mcp-Method"},
+    }
+    assert str(error) == "HeaderMismatch"
+
+
+# ---------------------------------------------------------------------------
+# ContextVar isolation between sequential requests
+# ---------------------------------------------------------------------------
+
+def test_context_var_defaults_to_none():
+    """Outside a request there is no negotiation state."""
+    assert get_current_negotiation() is None
+
+
+def test_sequential_requests_do_not_leak_capabilities():
+    """Request B never sees request A's declared capabilities."""
+    first = negotiate_request(
+        make_request(
+            {
+                META_PROTOCOL_VERSION: PROTOCOL_VERSION_2026,
+                META_CLIENT_CAPABILITIES: {"sampling": {}},
+                META_LOG_LEVEL: "info",
+            }
+        )
+    )
+
+    token = set_current_negotiation(first)
+    assert get_current_negotiation().client_capabilities == {"sampling": {}}
+    reset_current_negotiation(token)
+
+    # Between requests nothing is in scope.
+    assert get_current_negotiation() is None
+
+    second = negotiate_request(make_request({META_PROTOCOL_VERSION: PROTOCOL_VERSION_2026}))
+    token = set_current_negotiation(second)
+    try:
+        current = get_current_negotiation()
+        assert current.client_capabilities == {}
+        assert current.log_level is None
+    finally:
+        reset_current_negotiation(token)
+
+    assert get_current_negotiation() is None
+
+
+def test_negotiation_scope_resets_even_when_body_raises():
+    """The scope helper cannot leak state when the handler fails."""
+    negotiation = negotiation_from_meta({META_CLIENT_CAPABILITIES: {"tools": {}}})
+
+    with pytest.raises(RuntimeError):
+        with negotiation_scope(negotiation):
+            assert get_current_negotiation() is negotiation
+            raise RuntimeError("handler blew up")
+
+    assert get_current_negotiation() is None
+
+
+def test_nested_scopes_restore_the_outer_request():
+    """Resetting an inner scope restores, not clears, the outer state."""
+    outer = negotiation_from_meta({META_CLIENT_INFO: {"name": "outer"}})
+    inner = negotiation_from_meta({META_CLIENT_INFO: {"name": "inner"}})
+
+    with negotiation_scope(outer):
+        with negotiation_scope(inner):
+            assert get_current_negotiation().client_info == {"name": "inner"}
+        assert get_current_negotiation().client_info == {"name": "outer"}
+
+    assert get_current_negotiation() is None
+
+
+def test_reset_with_none_token_clears_state():
+    """Resetting without a token still leaves nothing behind."""
+    set_current_negotiation(negotiation_from_meta({}))
+    reset_current_negotiation(None)
+
+    assert get_current_negotiation() is None
+
+
+def test_reset_with_foreign_token_clears_state(monkeypatch):
+    """A token that ContextVar.reset rejects still results in a clean context."""
+    import contextvars
+
+    from prometheus_mcp_server.spec2026 import negotiation as negotiation_module
+
+    class BadVar:
+        def set(self, value):
+            self.value = value
+
+        def get(self):
+            return getattr(self, "value", None)
+
+        def reset(self, token):
+            raise ValueError("Token was created in a different Context")
+
+    bad_var = BadVar()
+    bad_var.set(negotiation_from_meta({META_CLIENT_INFO: {"name": "stale"}}))
+    monkeypatch.setattr(negotiation_module, "_CURRENT_NEGOTIATION", bad_var)
+
+    token = contextvars.ContextVar("throwaway", default=None).set(None)
+    negotiation_module.reset_current_negotiation(token)
+
+    assert bad_var.get() is None
+
+
+@pytest.mark.asyncio
+async def test_sequential_async_requests_are_isolated():
+    """Two awaited handlers in one task do not share negotiation state."""
+
+    async def handle(meta):
+        negotiation = negotiation_from_meta(meta)
+        with negotiation_scope(negotiation):
+            return get_current_negotiation()
+
+    first = await handle({META_LOG_LEVEL: "debug", META_CLIENT_INFO: {"name": "a"}})
+    assert get_current_negotiation() is None
+
+    second = await handle({})
+
+    assert first.log_level == "debug"
+    assert first.client_info == {"name": "a"}
+    assert second.log_level is None
+    assert second.client_info == {}
+    assert get_current_negotiation() is None
+
+
+# ---------------------------------------------------------------------------
+# logLevel gate
+# ---------------------------------------------------------------------------
+
+def test_log_level_absent_forbids_notifications():
+    """Without a declared log level the server must stay silent."""
+    negotiation = negotiate_request(make_request({META_PROTOCOL_VERSION: PROTOCOL_VERSION_2026}))
+
+    assert negotiation.log_level is None
+    assert negotiation.may_log is False
+    assert may_emit_log_notifications(negotiation) is False
+
+
+def test_log_level_present_permits_notifications():
+    """A declared log level opts the request into notifications/message."""
+    negotiation = negotiate_request(
+        make_request({META_PROTOCOL_VERSION: PROTOCOL_VERSION_2026, META_LOG_LEVEL: "warning"})
+    )
+
+    assert negotiation.log_level == "warning"
+    assert negotiation.may_log is True
+    assert may_emit_log_notifications(negotiation) is True
+
+
+def test_log_level_gate_reads_the_current_request_by_default():
+    """The gate consults the in-scope request when given no argument."""
+    assert may_emit_log_notifications() is False
+    assert current_log_level() is None
+
+    with negotiation_scope(negotiation_from_meta({META_LOG_LEVEL: "error"})):
+        assert may_emit_log_notifications() is True
+        assert current_log_level() == "error"
+
+    assert may_emit_log_notifications() is False
+    assert current_log_level() is None
+
+
+@pytest.mark.parametrize("bad_level", ["", "   ", 3, [], {"level": "info"}])
+def test_malformed_log_level_keeps_notifications_disabled(bad_level):
+    """An unusable log level fails closed instead of enabling notifications."""
+    negotiation = negotiation_from_meta({META_LOG_LEVEL: bad_level})
+
+    assert negotiation.log_level is None
+    assert may_emit_log_notifications(negotiation) is False
+
+
+def test_explicit_negotiation_argument_overrides_context():
+    """An explicitly supplied state wins over whatever is in scope."""
+    with negotiation_scope(negotiation_from_meta({META_LOG_LEVEL: "info"})):
+        assert may_emit_log_notifications(RequestNegotiation()) is False

--- a/tests/test_spec2026_otel.py
+++ b/tests/test_spec2026_otel.py
@@ -1,0 +1,552 @@
+"""Tests for MCP 2026-07-28 OpenTelemetry trace-context propagation (F7).
+
+Covers:
+- W3C traceparent validation, including the all-zero trace-id/parent-id and the
+  reserved ``ff`` version that are syntactically valid but semantically invalid.
+- Header-injection defence: no CR/LF (or any control character) may reach an
+  outbound HTTP header.
+- tracestate/baggage length and control-character limits.
+- Extraction from a request ``_meta`` in each shape it can arrive in.
+- The per-request contextvar and its reset path.
+"""
+
+import pytest
+
+from prometheus_mcp_server.spec2026 import otel
+from prometheus_mcp_server.spec2026.otel import (
+    BAGGAGE_HEADER,
+    MAX_BAGGAGE_LENGTH,
+    MAX_TRACESTATE_LENGTH,
+    TRACEPARENT_HEADER,
+    TRACESTATE_HEADER,
+    clear_trace_headers,
+    extract_trace_headers,
+    get_trace_headers,
+    is_safe_header_value,
+    meta_as_mapping,
+    reset_trace_headers,
+    set_trace_headers,
+    trace_context,
+    validate_baggage,
+    validate_traceparent,
+    validate_tracestate,
+)
+
+# Canonical example from the W3C Trace Context specification.
+VALID_TRACEPARENT = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+VALID_TRACESTATE = "rojo=00f067aa0ba902b7,congo=t61rcWkgMzE"
+VALID_BAGGAGE = "userId=alice,serverNode=DF%2028,isProduction=false"
+
+
+@pytest.fixture(autouse=True)
+def reset_trace_context():
+    """Keep the trace-header contextvar clean between tests."""
+    clear_trace_headers()
+    yield
+    clear_trace_headers()
+
+
+class TestValidateTraceparent:
+    """Tests for W3C traceparent validation."""
+
+    def test_valid_traceparent_accepted(self):
+        """A canonical W3C traceparent passes unchanged."""
+        assert validate_traceparent(VALID_TRACEPARENT) == VALID_TRACEPARENT
+
+    def test_valid_traceparent_unsampled_flags_accepted(self):
+        """Flags of 00 (not sampled) are still a valid traceparent."""
+        value = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00"
+        assert validate_traceparent(value) == value
+
+    def test_valid_future_version_accepted(self):
+        """Any two hex digits other than ff are an acceptable version."""
+        value = "01-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        assert validate_traceparent(value) == value
+
+    @pytest.mark.parametrize(
+        "version",
+        ["0", "000", "gg", "0g", "-0", "  ", "0x"],
+        ids=["one-digit", "three-digit", "non-hex", "half-hex", "dash", "spaces", "prefixed"],
+    )
+    def test_malformed_version_rejected(self, version):
+        """A version field that is not exactly two lowercase hex digits is dropped."""
+        value = f"{version}-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        assert validate_traceparent(value) is None
+
+    def test_reserved_ff_version_rejected(self):
+        """Version ff is reserved and forbidden by W3C."""
+        value = "ff-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        assert validate_traceparent(value) is None
+
+    def test_uppercase_hex_rejected(self):
+        """W3C mandates lowercase hex; uppercase is rejected, not folded."""
+        assert validate_traceparent(VALID_TRACEPARENT.upper()) is None
+
+    def test_all_zero_trace_id_rejected(self):
+        """An all-zero trace-id is invalid per W3C."""
+        value = f"00-{'0' * 32}-00f067aa0ba902b7-01"
+        assert validate_traceparent(value) is None
+
+    def test_all_zero_parent_id_rejected(self):
+        """An all-zero parent-id is invalid per W3C."""
+        value = f"00-4bf92f3577b34da6a3ce929d0e0e4736-{'0' * 16}-01"
+        assert validate_traceparent(value) is None
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "00-4bf92f3577b34da6a3ce929d0e0e473-00f067aa0ba902b7-01",
+            "00-4bf92f3577b34da6a3ce929d0e0e47366-00f067aa0ba902b7-01",
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b-01",
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b77-01",
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7",
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01-extra",
+            "004bf92f3577b34da6a3ce929d0e0e473600f067aa0ba902b701",
+            "",
+        ],
+        ids=[
+            "short-trace-id",
+            "long-trace-id",
+            "short-parent-id",
+            "long-parent-id",
+            "missing-flags",
+            "extra-field",
+            "no-separators",
+            "empty",
+        ],
+    )
+    def test_structurally_malformed_rejected(self, value):
+        """Field-length and separator violations are dropped."""
+        assert validate_traceparent(value) is None
+
+    @pytest.mark.parametrize(
+        "value",
+        [None, 42, 1.5, True, ["a"], {"a": 1}, VALID_TRACEPARENT.encode()],
+        ids=["none", "int", "float", "bool", "list", "dict", "bytes"],
+    )
+    def test_non_string_rejected(self, value):
+        """Non-string values are never coerced into a header."""
+        assert validate_traceparent(value) is None
+
+    @pytest.mark.parametrize(
+        "value",
+        [f" {VALID_TRACEPARENT}", f"{VALID_TRACEPARENT} ", f"\t{VALID_TRACEPARENT}"],
+        ids=["leading-space", "trailing-space", "leading-tab"],
+    )
+    def test_padded_traceparent_rejected(self, value):
+        """The traceparent grammar has no optional whitespace, so padding is invalid."""
+        assert validate_traceparent(value) is None
+
+    @pytest.mark.parametrize(
+        "suffix",
+        ["\r\nX-Injected: 1", "\nX-Injected: 1", "\rX-Injected: 1", "\x00"],
+        ids=["crlf", "lf", "cr", "nul"],
+    )
+    def test_crlf_injection_rejected(self, suffix):
+        """A traceparent carrying CR/LF must never be forwarded."""
+        assert validate_traceparent(VALID_TRACEPARENT + suffix) is None
+
+    def test_crlf_injection_inside_value_rejected(self):
+        """Injection in the middle of the value is rejected too."""
+        value = "00-4bf92f3577b34da6a3ce929d0e0e4736\r\nEvil: 1-00f067aa0ba902b7-01"
+        assert validate_traceparent(value) is None
+
+
+class TestValidateTracestate:
+    """Tests for tracestate length and character limits."""
+
+    def test_valid_tracestate_accepted(self):
+        """A well formed tracestate passes unchanged."""
+        assert validate_tracestate(VALID_TRACESTATE) == VALID_TRACESTATE
+
+    def test_surrounding_whitespace_trimmed(self):
+        """Optional whitespace around the value is insignificant and trimmed."""
+        assert validate_tracestate(f"  {VALID_TRACESTATE}  ") == VALID_TRACESTATE
+
+    def test_max_length_accepted(self):
+        """A value exactly at the limit is accepted."""
+        value = "a" * MAX_TRACESTATE_LENGTH
+        assert validate_tracestate(value) == value
+
+    def test_over_max_length_rejected(self):
+        """A value one character over the limit is dropped."""
+        assert validate_tracestate("a" * (MAX_TRACESTATE_LENGTH + 1)) is None
+
+    def test_length_measured_after_trimming(self):
+        """Padding does not push an otherwise legal value over the limit."""
+        value = "a" * MAX_TRACESTATE_LENGTH
+        assert validate_tracestate(f"  {value}  ") == value
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "rojo=1\r\nX-Injected: 1",
+            "rojo=1\nX-Injected: 1",
+            "rojo=1\rX-Injected: 1",
+            "rojo=1\x00",
+            "rojo=1\tcongo=2",
+            "rojo=1\x7f",
+            "rojo=café",
+        ],
+        ids=["crlf", "lf", "cr", "nul", "tab", "del", "non-ascii"],
+    )
+    def test_control_characters_rejected(self, value):
+        """Any character outside printable ASCII is rejected."""
+        assert validate_tracestate(value) is None
+
+    @pytest.mark.parametrize(
+        "value", ["", "   ", None, 42, ["rojo=1"]],
+        ids=["empty", "whitespace-only", "none", "int", "list"],
+    )
+    def test_empty_and_non_string_rejected(self, value):
+        """Empty, whitespace-only and non-string values are dropped."""
+        assert validate_tracestate(value) is None
+
+
+class TestValidateBaggage:
+    """Tests for baggage length and character limits."""
+
+    def test_valid_baggage_accepted(self):
+        """A well formed baggage value passes unchanged."""
+        assert validate_baggage(VALID_BAGGAGE) == VALID_BAGGAGE
+
+    def test_max_length_accepted(self):
+        """A value exactly at the limit is accepted."""
+        value = "b" * MAX_BAGGAGE_LENGTH
+        assert validate_baggage(value) == value
+
+    def test_over_max_length_rejected(self):
+        """A value one character over the limit is dropped."""
+        assert validate_baggage("b" * (MAX_BAGGAGE_LENGTH + 1)) is None
+
+    def test_baggage_limit_is_larger_than_tracestate_limit(self):
+        """Baggage has its own, larger W3C cap."""
+        assert MAX_BAGGAGE_LENGTH > MAX_TRACESTATE_LENGTH
+
+    @pytest.mark.parametrize(
+        "value",
+        ["k=v\r\nX-Injected: 1", "k=v\n", "k=v\r", "k=v\x00", "k=v\tj=w", "k=vé"],
+        ids=["crlf", "lf", "cr", "nul", "tab", "non-ascii"],
+    )
+    def test_control_characters_rejected(self, value):
+        """Any character outside printable ASCII is rejected."""
+        assert validate_baggage(value) is None
+
+    @pytest.mark.parametrize(
+        "value", ["", "   ", None, {"k": "v"}],
+        ids=["empty", "whitespace-only", "none", "dict"],
+    )
+    def test_empty_and_non_string_rejected(self, value):
+        """Empty, whitespace-only and non-string values are dropped."""
+        assert validate_baggage(value) is None
+
+
+class TestIsSafeHeaderValue:
+    """Tests for the printable-ASCII header guard."""
+
+    @pytest.mark.parametrize("value", ["", "abc", "a=1,b=2", "  padded  ", "~!@#$%^&*()"])
+    def test_printable_ascii_is_safe(self, value):
+        """Printable ASCII, including spaces, is safe."""
+        assert is_safe_header_value(value) is True
+
+    @pytest.mark.parametrize("value", ["a\r\nb", "a\nb", "a\rb", "a\tb", "a\x00b", "a\x7fb", "café"])
+    def test_control_and_non_ascii_is_unsafe(self, value):
+        """Control characters and non-ASCII are unsafe."""
+        assert is_safe_header_value(value) is False
+
+
+class TestMetaAsMapping:
+    """Tests for coercing the various ``_meta`` shapes into a dictionary."""
+
+    def test_none_returns_empty(self):
+        """A missing _meta yields an empty mapping."""
+        assert meta_as_mapping(None) == {}
+
+    def test_plain_dict_passthrough(self):
+        """A plain dict is copied, not aliased."""
+        source = {"traceparent": VALID_TRACEPARENT}
+        result = meta_as_mapping(source)
+        assert result == source
+        result["extra"] = "x"
+        assert "extra" not in source
+
+    def test_model_extra_is_read(self):
+        """Pydantic extension keys live in model_extra and are picked up."""
+
+        class FakeMeta:
+            model_extra = {"traceparent": VALID_TRACEPARENT}
+
+        assert meta_as_mapping(FakeMeta()) == {"traceparent": VALID_TRACEPARENT}
+
+    def test_model_dump_is_read(self):
+        """A model exposing only model_dump is still readable."""
+
+        class FakeMeta:
+            def model_dump(self):
+                return {"traceparent": VALID_TRACEPARENT}
+
+        assert meta_as_mapping(FakeMeta()) == {"traceparent": VALID_TRACEPARENT}
+
+    def test_model_extra_wins_over_model_dump(self):
+        """model_extra is authoritative for spec extension keys."""
+
+        class FakeMeta:
+            model_extra = {"traceparent": VALID_TRACEPARENT}
+
+            def model_dump(self):
+                return {"traceparent": "stale", "progressToken": 1}
+
+        result = meta_as_mapping(FakeMeta())
+        assert result["traceparent"] == VALID_TRACEPARENT
+        assert result["progressToken"] == 1
+
+    def test_unusable_object_returns_empty(self):
+        """An object with neither accessor degrades to an empty mapping."""
+        assert meta_as_mapping(object()) == {}
+
+    def test_non_mapping_returns_from_accessors_ignored(self):
+        """Accessors returning non-mappings are ignored rather than trusted."""
+
+        class FakeMeta:
+            model_extra = "not-a-mapping"
+
+            def model_dump(self):
+                return ["not-a-mapping"]
+
+        assert meta_as_mapping(FakeMeta()) == {}
+
+    def test_real_sdk_meta_model(self):
+        """The real SDK RequestParams.Meta model round-trips extension keys."""
+        from mcp.types import RequestParams
+
+        meta = RequestParams.Meta(**{"traceparent": VALID_TRACEPARENT})
+        assert meta_as_mapping(meta)["traceparent"] == VALID_TRACEPARENT
+
+
+class TestExtractTraceHeaders:
+    """Tests for building outbound headers from a request ``_meta``."""
+
+    @pytest.mark.parametrize(
+        "meta",
+        [None, {}, {"progressToken": 1}, object(), []],
+        ids=["none", "empty-dict", "unrelated-keys", "plain-object", "empty-list"],
+    )
+    def test_absent_meta_yields_empty_dict(self, meta):
+        """No trace context present means no headers to forward."""
+        assert extract_trace_headers(meta) == {}
+
+    def test_full_valid_set_forwarded(self):
+        """All three valid values are forwarded."""
+        headers = extract_trace_headers(
+            {
+                TRACEPARENT_HEADER: VALID_TRACEPARENT,
+                TRACESTATE_HEADER: VALID_TRACESTATE,
+                BAGGAGE_HEADER: VALID_BAGGAGE,
+            }
+        )
+        assert headers == {
+            TRACEPARENT_HEADER: VALID_TRACEPARENT,
+            TRACESTATE_HEADER: VALID_TRACESTATE,
+            BAGGAGE_HEADER: VALID_BAGGAGE,
+        }
+
+    def test_traceparent_only(self):
+        """A lone valid traceparent is forwarded."""
+        headers = extract_trace_headers({TRACEPARENT_HEADER: VALID_TRACEPARENT})
+        assert headers == {TRACEPARENT_HEADER: VALID_TRACEPARENT}
+
+    def test_case_insensitive_meta_keys(self):
+        """Meta keys are matched case-insensitively."""
+        headers = extract_trace_headers({"TraceParent": VALID_TRACEPARENT})
+        assert headers == {TRACEPARENT_HEADER: VALID_TRACEPARENT}
+
+    def test_exact_key_preferred_over_case_variant(self):
+        """An exact lowercase key wins over a differently cased duplicate."""
+        headers = extract_trace_headers(
+            {TRACEPARENT_HEADER: VALID_TRACEPARENT, "TRACEPARENT": "bogus"}
+        )
+        assert headers == {TRACEPARENT_HEADER: VALID_TRACEPARENT}
+
+    def test_malformed_traceparent_drops_traceparent_and_tracestate(self):
+        """tracestate must not be propagated without a valid traceparent."""
+        headers = extract_trace_headers(
+            {
+                TRACEPARENT_HEADER: "not-a-traceparent",
+                TRACESTATE_HEADER: VALID_TRACESTATE,
+                BAGGAGE_HEADER: VALID_BAGGAGE,
+            }
+        )
+        assert headers == {BAGGAGE_HEADER: VALID_BAGGAGE}
+
+    def test_tracestate_without_traceparent_dropped(self):
+        """A lone tracestate is meaningless and is dropped."""
+        headers = extract_trace_headers({TRACESTATE_HEADER: VALID_TRACESTATE})
+        assert headers == {}
+
+    def test_baggage_without_traceparent_kept(self):
+        """Baggage is an independent propagation format and stands alone."""
+        headers = extract_trace_headers({BAGGAGE_HEADER: VALID_BAGGAGE})
+        assert headers == {BAGGAGE_HEADER: VALID_BAGGAGE}
+
+    def test_oversized_tracestate_dropped_but_traceparent_kept(self):
+        """One bad value does not poison the others."""
+        headers = extract_trace_headers(
+            {
+                TRACEPARENT_HEADER: VALID_TRACEPARENT,
+                TRACESTATE_HEADER: "a" * (MAX_TRACESTATE_LENGTH + 1),
+            }
+        )
+        assert headers == {TRACEPARENT_HEADER: VALID_TRACEPARENT}
+
+    def test_crlf_injection_in_meta_yields_empty_dict(self):
+        """A hostile _meta cannot inject headers into the Prometheus request."""
+        headers = extract_trace_headers(
+            {
+                TRACEPARENT_HEADER: f"{VALID_TRACEPARENT}\r\nX-Injected: 1",
+                TRACESTATE_HEADER: "rojo=1\r\nX-Injected: 1",
+                BAGGAGE_HEADER: "k=v\r\nX-Injected: 1",
+            }
+        )
+        assert headers == {}
+
+    def test_no_forwarded_value_contains_crlf(self):
+        """Nothing that survives extraction may contain CR or LF."""
+        headers = extract_trace_headers(
+            {
+                TRACEPARENT_HEADER: VALID_TRACEPARENT,
+                TRACESTATE_HEADER: VALID_TRACESTATE,
+                BAGGAGE_HEADER: VALID_BAGGAGE,
+            }
+        )
+        for value in headers.values():
+            assert "\r" not in value and "\n" not in value
+
+    def test_pydantic_style_meta(self):
+        """A pydantic-style meta object is read via model_extra."""
+
+        class FakeMeta:
+            model_extra = {
+                TRACEPARENT_HEADER: VALID_TRACEPARENT,
+                BAGGAGE_HEADER: VALID_BAGGAGE,
+            }
+
+        headers = extract_trace_headers(FakeMeta())
+        assert headers == {
+            TRACEPARENT_HEADER: VALID_TRACEPARENT,
+            BAGGAGE_HEADER: VALID_BAGGAGE,
+        }
+
+    def test_real_sdk_meta_model(self):
+        """Extraction works against the real SDK RequestParams.Meta model."""
+        from mcp.types import RequestParams
+
+        meta = RequestParams.Meta(
+            **{
+                TRACEPARENT_HEADER: VALID_TRACEPARENT,
+                TRACESTATE_HEADER: VALID_TRACESTATE,
+            }
+        )
+        assert extract_trace_headers(meta) == {
+            TRACEPARENT_HEADER: VALID_TRACEPARENT,
+            TRACESTATE_HEADER: VALID_TRACESTATE,
+        }
+
+    def test_final_injection_guard_drops_poisoned_value(self, monkeypatch):
+        """Defence in depth: a validator returning CR/LF is still caught."""
+        monkeypatch.setattr(otel, "validate_baggage", lambda value: "evil\r\nX-Injected: 1")
+        assert extract_trace_headers({BAGGAGE_HEADER: "k=v"}) == {}
+
+    def test_exception_during_extraction_degrades_to_empty(self):
+        """A hostile or unexpected meta object never propagates an exception."""
+
+        class ExplodingMeta:
+            @property
+            def model_extra(self):
+                raise RuntimeError("boom")
+
+        assert extract_trace_headers(ExplodingMeta()) == {}
+
+
+class TestTraceHeaderContext:
+    """Tests for the per-request contextvar and its reset path."""
+
+    def test_default_is_empty(self):
+        """Nothing stashed means no headers."""
+        assert get_trace_headers() == {}
+
+    def test_set_and_get(self):
+        """Stashed headers are readable."""
+        set_trace_headers({TRACEPARENT_HEADER: VALID_TRACEPARENT})
+        assert get_trace_headers() == {TRACEPARENT_HEADER: VALID_TRACEPARENT}
+
+    def test_set_none_stores_empty(self):
+        """Setting None stashes an empty mapping."""
+        set_trace_headers(None)
+        assert get_trace_headers() == {}
+
+    def test_getter_returns_a_copy(self):
+        """Callers cannot mutate the stored state through the getter."""
+        set_trace_headers({TRACEPARENT_HEADER: VALID_TRACEPARENT})
+        borrowed = get_trace_headers()
+        borrowed["injected"] = "evil"
+        assert get_trace_headers() == {TRACEPARENT_HEADER: VALID_TRACEPARENT}
+
+    def test_setter_copies_input(self):
+        """Later mutation of the caller's dict does not affect stored state."""
+        source = {TRACEPARENT_HEADER: VALID_TRACEPARENT}
+        set_trace_headers(source)
+        source["injected"] = "evil"
+        assert get_trace_headers() == {TRACEPARENT_HEADER: VALID_TRACEPARENT}
+
+    def test_reset_restores_previous_value(self):
+        """The token restores exactly the prior value."""
+        set_trace_headers({TRACEPARENT_HEADER: VALID_TRACEPARENT})
+        token = set_trace_headers({BAGGAGE_HEADER: VALID_BAGGAGE})
+        assert get_trace_headers() == {BAGGAGE_HEADER: VALID_BAGGAGE}
+        reset_trace_headers(token)
+        assert get_trace_headers() == {TRACEPARENT_HEADER: VALID_TRACEPARENT}
+
+    def test_reset_with_stale_token_is_logged_not_raised(self):
+        """A double reset must not break request handling."""
+        token = set_trace_headers({TRACEPARENT_HEADER: VALID_TRACEPARENT})
+        reset_trace_headers(token)
+        reset_trace_headers(token)
+        assert get_trace_headers() == {}
+
+    def test_clear(self):
+        """Clearing drops whatever was stashed."""
+        set_trace_headers({TRACEPARENT_HEADER: VALID_TRACEPARENT})
+        clear_trace_headers()
+        assert get_trace_headers() == {}
+
+    def test_trace_context_sets_and_restores(self):
+        """The context manager stashes on entry and restores on exit."""
+        meta = {TRACEPARENT_HEADER: VALID_TRACEPARENT}
+        with trace_context(meta) as headers:
+            assert headers == {TRACEPARENT_HEADER: VALID_TRACEPARENT}
+            assert get_trace_headers() == {TRACEPARENT_HEADER: VALID_TRACEPARENT}
+        assert get_trace_headers() == {}
+
+    def test_trace_context_restores_on_exception(self):
+        """The previous value is restored even when the block raises."""
+        set_trace_headers({BAGGAGE_HEADER: VALID_BAGGAGE})
+        with pytest.raises(ValueError):
+            with trace_context({TRACEPARENT_HEADER: VALID_TRACEPARENT}):
+                raise ValueError("boom")
+        assert get_trace_headers() == {BAGGAGE_HEADER: VALID_BAGGAGE}
+
+    def test_trace_context_with_invalid_meta_yields_empty(self):
+        """Invalid trace context stashes nothing."""
+        with trace_context({TRACEPARENT_HEADER: "bogus"}) as headers:
+            assert headers == {}
+            assert get_trace_headers() == {}
+
+    def test_headers_are_mergeable_into_outbound_request(self):
+        """The stashed headers merge cleanly onto existing request headers."""
+        set_trace_headers(extract_trace_headers({TRACEPARENT_HEADER: VALID_TRACEPARENT}))
+        outbound = {"X-Scope-OrgID": "tenant-1"}
+        outbound.update(get_trace_headers())
+        assert outbound == {
+            "X-Scope-OrgID": "tenant-1",
+            TRACEPARENT_HEADER: VALID_TRACEPARENT,
+        }


### PR DESCRIPTION
## Summary

Adds support for the MCP `2026-07-28` specification. The installed SDK (`mcp` 1.29.0) still implements `2025-11-25`, so these features are added as an **additive server-side layer** in a new `prometheus_mcp_server.spec2026` package rather than waiting on the SDK.

Existing `2025-11-25` clients are unaffected, and the entire layer can be turned off with `PROMETHEUS_MCP_SPEC_2026=false`.

## What's implemented

| Feature | SEP | Notes |
|---|---|---|
| `server/discover` | SEP-2575 | Real JSON-RPC dispatch (stdio/HTTP/SSE), plus `GET /server/discover` for pre-handshake discovery, plus a tool |
| `CacheableResult` (`ttlMs`/`cacheScope`) | SEP-2549 | On the six cacheable methods only, never on `tools/call` |
| `resultType` on all results | SEP-2322 | Including `initialize` |
| Deterministic `tools/list` ordering | — | Sorted by name, for client prompt-cache hits |
| Per-request `_meta` negotiation | SEP-2575 | Returns `UnsupportedProtocolVersionError` (-32022) |
| `Mcp-*` header validation | SEP-2243 | Base64 sentinel codec; HTTP 400 + `HeaderMismatch` (-32020) |
| `x-mcp-header` | SEP-2243 | Wired to the multi-tenant `X-Scope-OrgID` header |
| OTel trace propagation | SEP-414 | W3C-validated `traceparent`/`tracestate`/`baggage` |
| `extensions` capability, `-32602` | — | Resource-not-found renumbered from `-32002` |

## Out of scope

Four spec items require SDK-internal transport rewrites and are deliberately **not** attempted: removing the `initialize` handshake, `subscriptions/listen`, SSE-resumability removal, and the tasks extension. As a result `server/discover` over JSON-RPC still requires `initialize` first; the `GET` route is the pre-handshake answer.

## Security

An operator-configured `ORG_ID` always takes precedence over a client-supplied `org_id` unless `PROMETHEUS_MCP_ALLOW_ORG_ID_OVERRIDE=true`. Since `X-Scope-OrgID` is the only tenancy boundary in multi-tenant Mimir/Cortex/Thanos, and the caller is typically an LLM, allowing a client to override it would have been a cross-tenant data-access path. The value is also rejected unless it is safe plain ASCII, so CR/LF cannot reach the outbound header.

## Also fixed

A latent packaging bug: `[tool.setuptools] packages` listed only the top-level package, so built wheels excluded `spec2026` while `server.py` imports it at module load. Confirmed by building a wheel before/after and installing into a clean venv.

## New configuration

All optional and backward compatible:

- `PROMETHEUS_MCP_SPEC_2026` (default `true`)
- `PROMETHEUS_MCP_CACHE_TTL_MS` (default `300000`)
- `PROMETHEUS_MCP_CACHE_SCOPE` (default `public`)
- `PROMETHEUS_MCP_STRICT_HEADERS` (default `false`)
- `PROMETHEUS_MCP_ALLOW_ORG_ID_OVERRIDE` (default `false`)

## Testing

- **757 tests pass**, total coverage **99.90%** (gate is 80%); every `spec2026` module is at 100%
- All 154 pre-existing tests still pass; two that broke were fixed in production code, not by weakening assertions
- End-to-end verified against the real `main.run_server()` path under uvicorn with a stock `fastmcp.Client`: `server/discover` over both the HTTP route and JSON-RPC, strict-header rejection returning 400 + `-32020`, and a cold `tools/call`
- Backward compat verified with the layer disabled: clean `2025-11-25` responses, no envelope fields
