### PR TITLE
fix(get_targets): filter server-side to prevent memory exhaustion

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ See the [chart values](charts/prometheus-mcp-server/values.yaml) for all availab
 | `execute_range_query` | Query | Execute a PromQL range query with start time, end time, and step interval |
 | `list_metrics` | Discovery | List all available metrics in Prometheus with pagination and filtering support |
 | `get_metric_metadata` | Discovery | Get metadata for one metric or bulk metadata with optional filtering |
-| `get_targets` | Discovery | Get information about all scrape targets |
+| `get_targets` | Discovery | Get scrape targets, with server-side `state`/`scrape_pool` filtering and optional pagination |
 
 The list of tools is configurable, so you can choose which tools you want to make available to the MCP client. This is useful if you don't use certain functionality or if you don't want to take up too much of the context window.
 

--- a/src/prometheus_mcp_server/server.py
+++ b/src/prometheus_mcp_server/server.py
@@ -629,7 +629,7 @@ async def get_metric_metadata(
 
 @mcp.tool(
     name=_tool_name("get_targets"),
-    description="Get information about all scrape targets",
+    description="Get scrape targets, with state/pool filtering and optional pagination",
     annotations={
         "title": "Get Scrape Targets",
         "icon": "🎯",
@@ -639,24 +639,88 @@ async def get_metric_metadata(
         "openWorldHint": True
     }
 )
-async def get_targets() -> Dict[str, List[Dict[str, Any]]]:
-    """Get information about all Prometheus scrape targets.
+async def get_targets(
+    state: str = "active",
+    scrape_pool: Optional[str] = None,
+    limit: Optional[int] = None,
+    offset: int = 0,
+) -> Dict[str, Any]:
+    """Get information about Prometheus scrape targets.
+
+    Args:
+        state: Which targets to request from Prometheus - "active" (default),
+            "dropped", or "any". This is applied server-side by Prometheus.
+        scrape_pool: Optional scrape pool name to restrict results to, applied
+            server-side by Prometheus.
+        limit: Maximum number of targets to return per category (default: all)
+        offset: Number of targets to skip for pagination (default: 0)
 
     Returns:
-        Dictionary with active and dropped targets information
+        Dictionary containing:
+        - activeTargets / droppedTargets: Target lists (after pagination)
+        - total_active / total_dropped: Totals before pagination
+        - returned_active / returned_dropped: Counts actually returned
+        - offset: Current offset
+        - has_more: Whether more targets are available
+        - state: The state filter that was applied
+
+    Note:
+        The default is "active" rather than "any" deliberately. On a cluster of
+        any size, service discovery finds far more targets than relabeling
+        keeps, and each dropped target carries its full discoveredLabels map.
+        Requesting dropped targets unfiltered can produce a response large
+        enough to exhaust the server's memory before any pagination could be
+        applied, since the whole payload is parsed first. Pass state="any" or
+        "dropped" explicitly when you need them, ideally with scrape_pool.
     """
-    logger.info("Retrieving scrape targets information")
-    data = make_prometheus_request("targets")
-    
+    valid_states = ("active", "dropped", "any")
+    if state not in valid_states:
+        raise ValueError(f"Invalid state '{state}'. Must be one of: {', '.join(valid_states)}")
+    if offset < 0:
+        raise ValueError("offset must be non-negative")
+    if limit is not None and limit < 0:
+        raise ValueError("limit must be non-negative")
+
+    logger.info("Retrieving scrape targets information",
+                state=state, scrape_pool=scrape_pool, limit=limit, offset=offset)
+
+    # Filter server-side so Prometheus never sends what we do not need.
+    params: Dict[str, str] = {}
+    if state != "any":
+        params["state"] = state
+    if scrape_pool:
+        params["scrapePool"] = scrape_pool
+
+    data = make_prometheus_request("targets", params=params or None)
+
+    active = data.get("activeTargets", []) or []
+    dropped = data.get("droppedTargets", []) or []
+    total_active, total_dropped = len(active), len(dropped)
+
+    if limit is not None:
+        end = offset + limit
+        active, dropped = active[offset:end], dropped[offset:end]
+    elif offset:
+        active, dropped = active[offset:], dropped[offset:]
+
     result = {
-        "activeTargets": data["activeTargets"],
-        "droppedTargets": data["droppedTargets"]
+        "activeTargets": active,
+        "droppedTargets": dropped,
+        "total_active": total_active,
+        "total_dropped": total_dropped,
+        "returned_active": len(active),
+        "returned_dropped": len(dropped),
+        "offset": offset,
+        "has_more": offset + len(active) < total_active or offset + len(dropped) < total_dropped,
+        "state": state,
     }
-    
-    logger.info("Scrape targets retrieved", 
-                active_targets=len(data["activeTargets"]), 
-                dropped_targets=len(data["droppedTargets"]))
-    
+
+    logger.info("Scrape targets retrieved",
+                active_targets=total_active,
+                dropped_targets=total_dropped,
+                returned_active=len(active),
+                returned_dropped=len(dropped))
+
     return result
 
 if __name__ == "__main__":

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -311,10 +311,118 @@ async def test_get_targets(mock_make_request):
         json_data = json.loads(payload)
 
         # Verify
-        mock_make_request.assert_called_once_with("targets")
+        # Defaults to active-only, filtered server-side by Prometheus.
+        mock_make_request.assert_called_once_with("targets", params={"state": "active"})
         assert len(json_data["activeTargets"]) == 1
         assert json_data["activeTargets"][0]["health"] == "up"
         assert len(json_data["droppedTargets"]) == 0
+        assert json_data["total_active"] == 1
+        assert json_data["total_dropped"] == 0
+        assert json_data["state"] == "active"
+        assert json_data["has_more"] is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "state,expected_params",
+    [
+        ("active", {"state": "active"}),
+        ("dropped", {"state": "dropped"}),
+        ("any", None),
+    ],
+)
+async def test_get_targets_state_filter(mock_make_request, state, expected_params):
+    """state is passed through to Prometheus; 'any' sends no filter."""
+    mock_make_request.return_value = {"activeTargets": [], "droppedTargets": []}
+
+    async with Client(mcp) as client:
+        await client.call_tool("get_targets", {"state": state})
+
+    mock_make_request.assert_called_once_with("targets", params=expected_params)
+
+
+@pytest.mark.asyncio
+async def test_get_targets_scrape_pool_filter(mock_make_request):
+    """scrape_pool is passed through to Prometheus alongside state."""
+    mock_make_request.return_value = {"activeTargets": [], "droppedTargets": []}
+
+    async with Client(mcp) as client:
+        await client.call_tool("get_targets", {"scrape_pool": "node_exporter"})
+
+    mock_make_request.assert_called_once_with(
+        "targets", params={"state": "active", "scrapePool": "node_exporter"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_targets_pagination(mock_make_request):
+    """limit/offset slice each category and report accurate totals."""
+    mock_make_request.return_value = {
+        "activeTargets": [{"labels": {"i": str(i)}} for i in range(5)],
+        "droppedTargets": [],
+    }
+
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "get_targets", {"state": "any", "limit": 2, "offset": 1}
+        )
+        json_data = json.loads(result.content[0].text)
+
+    assert [t["labels"]["i"] for t in json_data["activeTargets"]] == ["1", "2"]
+    assert json_data["total_active"] == 5
+    assert json_data["returned_active"] == 2
+    assert json_data["offset"] == 1
+    assert json_data["has_more"] is True
+
+
+@pytest.mark.asyncio
+async def test_get_targets_offset_without_limit(mock_make_request):
+    """offset alone skips without truncating the remainder."""
+    mock_make_request.return_value = {
+        "activeTargets": [{"labels": {"i": str(i)}} for i in range(3)],
+        "droppedTargets": [],
+    }
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("get_targets", {"offset": 2})
+        json_data = json.loads(result.content[0].text)
+
+    assert json_data["returned_active"] == 1
+    assert json_data["total_active"] == 3
+    assert json_data["has_more"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_targets_handles_missing_keys(mock_make_request):
+    """A response omitting either category should not raise."""
+    mock_make_request.return_value = {}
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("get_targets", {})
+        json_data = json.loads(result.content[0].text)
+
+    assert json_data["activeTargets"] == []
+    assert json_data["total_dropped"] == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"state": "bogus"},
+        {"offset": -1},
+        {"limit": -5},
+    ],
+)
+async def test_get_targets_rejects_invalid_arguments(mock_make_request, kwargs):
+    """Invalid arguments fail before any request is made."""
+    from fastmcp.exceptions import ToolError
+
+    async with Client(mcp) as client:
+        with pytest.raises(ToolError):
+            await client.call_tool("get_targets", kwargs)
+
+    mock_make_request.assert_not_called()
 
 
 # --- Helper function unit tests ---


### PR DESCRIPTION
Fixes #185

## Problem

`get_targets()` calls `/api/v1/targets` with no query parameters and returns every dropped target verbatim:

```python
data = make_prometheus_request("targets")
result = {
    "activeTargets": data["activeTargets"],
    "droppedTargets": data["droppedTargets"],
}
```

Prometheus supports `state` and `scrapePool` filters on that endpoint. Neither is used, and the tool accepts no arguments at all.

Because dropped targets each carry their full `discoveredLabels` map, and endpoint service discovery finds far more targets than relabeling keeps, the response scales with **cluster size** rather than with the number of targets actually scraped. Measured against a cluster with 177 active targets and 83 scrape configs:

| request | response |
| --- | --- |
| `/api/v1/targets` | **22.2 MB** (177 active + 4,381 dropped) |
| `/api/v1/targets?state=active` | **0.9 MB** |

~4.9 KB per dropped target. Parsing 22.2 MB of JSON expands to roughly 150–250 MB of Python objects, which OOM-killed a 256Mi container (exit 137) on a single call, after 11 days of flat ~72 MB memory.

**Pagination alone cannot fix this.** The full payload is fetched and parsed inside `make_prometheus_request` before any slicing could apply, so the peak allocation has already happened. Server-side filtering is what prevents it.

## Change

Three parameters, in order of importance:

| parameter | effect | where |
| --- | --- | --- |
| `state` (`"active"`/`"dropped"`/`"any"`) | `?state=` | server-side — prevents the allocation |
| `scrape_pool` | `?scrapePool=` | server-side — narrows further |
| `limit` / `offset` | slices each category | client-side — bounds the response |

`limit`/`offset` deliberately mirror the existing `list_metrics` signature, and the response gains `total_active`, `total_dropped`, `returned_active`, `returned_dropped`, `offset` and `has_more` alongside it. The existing `activeTargets` / `droppedTargets` keys are unchanged.

Invalid `state`, negative `offset` and negative `limit` raise before any request is made.

## Behaviour change: the default

The default is now `state="active"` rather than everything. This is the one judgement call in the PR and I want to flag it rather than bury it.

The reasoning: `get_targets()` with no arguments is the call every client makes, and it is precisely the call that crashes. Leaving the default unbounded and only *offering* filters would leave the reported bug reachable by default, which does not really fix it.

Dropped targets remain fully available via `state="dropped"` or `state="any"`, ideally combined with `scrape_pool`. If you would rather keep `"any"` as the default and treat this purely as an opt-in capability, I am happy to change it — it is a one-line change plus a test.

## Testing

Full suite passes and coverage improves:

```
164 passed
src/prometheus_mcp_server/server.py    96.3% -> 99.8%
TOTAL                                  96.18% -> 99.15%
```

Seven cases added covering state passthrough (including `"any"` sending no filter), `scrapePool`, pagination, offset-without-limit, responses missing either category, and argument validation. The existing `test_get_targets` is updated for the new call signature and asserts the new fields.

Also built the image and exercised it against a real Prometheus at the same 256Mi limit that previously OOM'd:

| call | response |
| --- | --- |
| default (`state="active"`) | 0.85 MB |
| `state="any"` | 2.8 MB |
| `state="any", limit=5` | 61 KB |
| `scrape_pool=...` | 15 KB |
| `state="bogus"` | rejected |

Peak memory **88.76 MiB / 256 MiB (34.7%)**, `OOMKilled: false`, no restarts.

## Notes

- README tool table updated.
- No new dependencies; `make_prometheus_request` already accepted `params`.
- Line length, docstrings, type hints and commit message format follow CONTRIBUTING.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added filtering of targets by state and scrape pool.
  * Added optional pagination with limit and offset controls.
  * Responses now include total and returned target counts plus pagination details.
  * Active targets are shown by default.

* **Bug Fixes**
  * Added validation for invalid filter and pagination values.

* **Documentation**
  * Updated tool documentation to describe filtering and pagination options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->